### PR TITLE
Fix incremental native composed projection performance and correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ also replay their own authored records into an independent mirror so its
 reconstructed layer stack remains complete; the emitter's authoring stage is
 not used as that mirror.
 
+> [!IMPORTANT]
+> Changing a context-dependent `ArResolver` mapping while managed native
+> projection is running pauses incremental delivery. Recreate the
+> receiver/dispatcher, rebind a replacement stage, restart the integration, or
+> destructively rebuild the native scene and call
+> `acknowledge_native_scene_rebuilt()`. The dispatcher
+> exposes `native_scene_rebuild_required` and raises `NativeSceneRebuildRequired`
+> before draining more input, so this condition cannot silently desynchronize
+> the native scene. Ordinary authored USD changes remain incremental.
+
 ## Features
 
 ### Sync server

--- a/docs/usd-native-integration.md
+++ b/docs/usd-native-integration.md
@@ -162,6 +162,22 @@ composed result into Blender. A receive-only USD application such as usdview
 can apply directly to its displayed stage because that stage is not also its
 authoring source.
 
+### Adapter destination contract
+
+`DCCAdapter.targets_stage()` selects the layered receive path. An adapter that
+writes directly into USD must return the exact `Usd.Stage` instance it mutates;
+`UsdStageAdapter` implements this contract. When that object is also the
+receiver's mirror stage, OpenUSD performs composition and the dispatcher skips
+composed projection.
+
+An adapter that writes into an external scene, such as Blender objects, returns
+`None`. The dispatcher then authors incoming records into its USD mirror and
+projects the mirror's composed result into the adapter. Returning a different
+`Usd.Stage` also selects projection because it is a separate destination, even
+if it was opened from equivalent layers. The comparison uses object identity,
+not layer or identifier equivalence. Custom stage-backed adapters must override
+`targets_stage()`; inheriting `None` opts into external-scene projection.
+
 Native Unreal currently uses the lower-level flat path around its
 `USDStageActor`. Flat replay is a single-layer compatibility path: servers with
 department policy, multiple collaboration layers, or a muted collaboration
@@ -279,6 +295,29 @@ process's `ArResolver` plugin and context.
 Use `receiver.refresh_asset_dependency()` after resolver state or an asset
 mapping changes. Use `receiver.pending_asset_dependencies` to inspect paths
 that still do not resolve.
+
+### Runtime resolver-context changes
+
+Managed native projection does not incrementally synchronize topology changes
+caused only by refreshing a context-dependent `ArResolver` context. Its
+previous-state stage shares the immutable base root layer with the live stage
+to keep startup, memory use, and normal transaction latency low. A resolver
+refresh can therefore recompose both stages before the dispatcher has observed
+the former topology.
+
+After changing a context-dependent resolver mapping, the dispatcher logs an
+error, sets `native_scene_rebuild_required`, and raises
+`NativeSceneRebuildRequired` before draining more receiver input. Recreate
+the receiver/dispatcher or rebind a replacement stage, and reconstruct the
+native adapter scene from the current composed stage. A destructive full native
+resync is equivalent; after it succeeds, call
+`acknowledge_native_scene_rebuilt()` to resume delivery. Restarting the
+integration is the simplest fallback when it does not expose either operation.
+An ordinary network reconnect that retains the same dispatcher does not clear
+the guard. Ordinary USD edits, filesystem asset appearance, and explicit
+reference or payload changes continue to use their normal incremental paths;
+this restriction applies only to composition changes caused solely by a live
+resolver-context refresh.
 
 ## Identity and authentication
 

--- a/openusdconnect/adapters.py
+++ b/openusdconnect/adapters.py
@@ -171,7 +171,14 @@ _DISPATCH: dict[str, Callable[[dict], dict]] = {
 
 
 class DCCAdapter(ABC):
-    """Abstract interface a DCC integration must implement."""
+    """Abstract interface a receiving scene integration must implement.
+
+    Subclasses that write directly into a ``Usd.Stage`` must override
+    :meth:`targets_stage`. Adapters for an external scene, such as native DCC
+    objects, inherit its default ``None`` result. That distinction controls
+    whether layered dispatch applies authored events directly to the mirror
+    stage or projects the mirror's composed result into a separate scene.
+    """
 
     def apply_event(self, event: dict):
         """Route one protocol event dict to the matching adapter method."""
@@ -188,11 +195,22 @@ class DCCAdapter(ABC):
         return len(events)
 
     def targets_stage(self) -> Usd.Stage | None:
-        """Return the ``Usd.Stage`` this adapter writes to, or ``None``.
+        """Declare whether this adapter writes directly into a ``Usd.Stage``.
 
-        Stage-backed adapters override this; DCC-backed adapters return
-        ``None``. The dispatcher uses it to detect when its ``mirror_stage``
-        is the same instance and skip the otherwise-redundant mirror commit.
+        Return the exact stage instance mutated by :meth:`apply_events`, or
+        ``None`` when the adapter writes to an external/native scene. This is
+        an architectural capability declaration, not descriptive metadata.
+
+        During layered replay, returning the same object as the dispatcher's
+        mirror stage means OpenUSD itself provides composition, so events are
+        applied directly and composed projection is skipped. Returning
+        ``None`` or a different stage enables before/after composed projection
+        into the adapter's separate destination. Stage identity is tested with
+        ``is``; an equivalent stage opened from the same layers is still a
+        separate destination.
+
+        Stage-backed adapters must override this method. External-scene
+        adapters should inherit the default ``None`` result.
         """
         return None
 

--- a/openusdconnect/composed_projection.py
+++ b/openusdconnect/composed_projection.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import cast
 
-from pxr import Sdf, Usd, UsdGeom, UsdShade
+from pxr import Sdf, Tf, Usd, UsdGeom, UsdShade
 
 from .protocol_constants import (
     EVENT_KEYS,
@@ -79,22 +79,160 @@ class _ProjectionCandidates:
     arcs: set[tuple[str, str]] = dataclass_field(default_factory=set)
 
 
-@dataclass(frozen=True)
+@dataclass(slots=True)
+class _PrimProjectionBaseline:
+    """Adapter-visible state retained for one composed prim."""
+
+    valid: bool = False
+    type_state: tuple[str, tuple[str, ...]] | None = None
+    xforms: dict[float | None, object | None] | None = None
+    gprim: dict[float | None, dict[str, object]] | None = None
+    variants: dict[str, str] | None = None
+    materials: dict[str, str] | None = None
+    connectables: dict[float | None, dict] | None = None
+    active: bool | None = None
+    visibility: dict[float | None, bool | None] | None = None
+    instanceable: bool | None = None
+    point_instancers: dict[float | None, dict[str, object]] | None = None
+    arcs: dict[str, list[dict]] | None = None
+
+
+@dataclass(slots=True)
 class _ProjectionBaseline:
     """Selected composed state captured immediately before a transaction."""
 
-    valid: dict[str, bool]
-    types: dict[str, tuple[str, tuple[str, ...]] | None]
-    xforms: dict[_PrimTime, object | None]
-    gprim: dict[_PrimTime, dict[str, object]]
-    variants: dict[str, dict[str, str]]
-    materials: dict[tuple[str, str], str]
-    connectables: dict[_PrimTime, dict]
-    active: dict[str, bool | None]
-    visibility: dict[_PrimTime, bool | None]
-    instanceable: dict[str, bool | None]
-    point_instancers: dict[_PrimTime, dict[str, object]]
-    arcs: dict[tuple[str, str], list[dict]]
+    prims: dict[str, _PrimProjectionBaseline] = dataclass_field(default_factory=dict)
+
+    def ensure(self, prim_path: str) -> _PrimProjectionBaseline:
+        state = self.prims.get(prim_path)
+        if state is None:
+            state = _PrimProjectionBaseline()
+            self.prims[prim_path] = state
+        return state
+
+
+_EMPTY_PRIM_BASELINE = _PrimProjectionBaseline()
+
+
+def _path_is_at_or_below(path: str, root: str) -> bool:
+    return root == "/" or path == root or path.startswith(root.rstrip("/") + "/")
+
+
+def _is_projectable_prim(prim: Usd.Prim) -> bool:
+    """Return whether a composed prim belongs in an external native scene."""
+    if not (
+        prim
+        and prim.IsValid()
+        and not prim.IsPseudoRoot()
+        and not prim.IsAbstract()
+        and not prim.IsInPrototype()
+    ):
+        return False
+    # Empty typeless ancestors created implicitly by DefinePrim only provide
+    # namespace. Native adapters create that hierarchy while ensuring the
+    # first representable descendant, so emitting a separate object would be
+    # both redundant and a behavior change from direct event projection.
+    return bool(prim.GetTypeName() or prim.GetAuthoredProperties() or not tuple(prim.GetChildren()))
+
+
+class ComposedProjectionState:
+    """Persistent native-visible state for one mirror stage and adapter.
+
+    ``Usd.Notice.ObjectsChanged`` identifies composed consumers only after a
+    layer mutation has occurred. Keeping the last successfully-applied native
+    state makes those post-change paths diffable without accessing the stage's
+    private Pcp cache or scanning every prim for each transaction.
+    """
+
+    def __init__(self, stage: Usd.Stage | None = None):
+        self._stage: Usd.Stage | None = None
+        self._baseline: _ProjectionBaseline | None = None
+        self._needs_full_reconcile = False
+        if stage is not None:
+            self.bind(stage)
+
+    @property
+    def baseline(self) -> _ProjectionBaseline:
+        if self._baseline is None:
+            raise RuntimeError("composed projection state is not bound")
+        return self._baseline
+
+    @property
+    def needs_full_reconcile(self) -> bool:
+        return self._needs_full_reconcile
+
+    def bind(self, stage: Usd.Stage) -> None:
+        if stage is self._stage and self._baseline is not None:
+            return
+        self._stage = stage
+        self._baseline = ComposedChangeProjection._capture_scope(
+            stage,
+            ("/",),
+            recurse=True,
+        )
+        self._needs_full_reconcile = False
+
+    def close(self) -> None:
+        self._stage = None
+        self._baseline = None
+        self._needs_full_reconcile = False
+
+    def require_full_reconcile(self) -> None:
+        """Keep the last adapter baseline but widen the next projection."""
+        if self._baseline is not None:
+            self._needs_full_reconcile = True
+
+    def commit(self, projection: ComposedChangeProjection) -> None:
+        """Advance the baseline after the native adapter applied successfully."""
+        if projection._state is not self:
+            raise ValueError("projection belongs to a different persistent state")
+        stage = projection._stage
+        if stage is not self._stage:
+            raise ValueError("projection stage no longer matches persistent state")
+
+        subtree_roots = set(projection._resync_prim_roots)
+        exact_paths = set(projection._affected_prim_paths)
+        exact_paths = {
+            path
+            for path in exact_paths
+            if not any(_path_is_at_or_below(path, root) for root in subtree_roots)
+        }
+
+        if not subtree_roots and not exact_paths:
+            self._needs_full_reconcile = False
+            return
+
+        if "/" in subtree_roots:
+            self._baseline = ComposedChangeProjection._capture_scope(
+                stage,
+                ("/",),
+                recurse=True,
+            )
+            self._needs_full_reconcile = False
+            return
+
+        if subtree_roots:
+            removed_paths = {
+                path
+                for path in self.baseline.prims
+                if any(_path_is_at_or_below(path, root) for root in subtree_roots)
+            }
+            for path in removed_paths:
+                self.baseline.prims.pop(path, None)
+            self.baseline.prims.update(
+                ComposedChangeProjection._capture_scope(
+                    stage, subtree_roots, recurse=True
+                ).prims
+            )
+        if exact_paths:
+            for path in exact_paths:
+                self.baseline.prims.pop(path, None)
+            self.baseline.prims.update(
+                ComposedChangeProjection._capture_scope(
+                    stage, exact_paths, recurse=False
+                ).prims
+            )
+        self._needs_full_reconcile = False
 
 
 @dataclass(frozen=True)
@@ -194,9 +332,7 @@ _PROJECTION_STEPS = (
 )
 
 _PROJECTOR_EVENT_KINDS = frozenset().union(*(step.event_kinds for step in _PROJECTION_STEPS))
-_PROJECTOR_EVENT_OWNERS = Counter(
-    kind for step in _PROJECTION_STEPS for kind in step.event_kinds
-)
+_PROJECTOR_EVENT_OWNERS = Counter(kind for step in _PROJECTION_STEPS for kind in step.event_kinds)
 
 if any(
     (step.candidate_name is None) != (step.collector_name is None) for step in _PROJECTION_STEPS
@@ -320,12 +456,20 @@ def _local_transforms(
     candidates: Iterable[tuple[str, float | None]],
 ) -> dict[tuple[str, float | None], object | None]:
     result: dict[tuple[str, float | None], object | None] = {}
+    times_by_prim: dict[str, list[float | None]] = defaultdict(list)
     for prim_path, time in candidates:
+        times_by_prim[prim_path].append(time)
+    for prim_path, times in times_by_prim.items():
         prim = stage.GetPrimAtPath(prim_path)
-        xformable = UsdGeom.Xformable(prim) if prim and prim.IsValid() else None
-        result[(prim_path, time)] = (
-            as_matrix(xformable.GetLocalTransformation(_time_code(time))) if xformable else None
-        )
+        xformable = UsdGeom.Xformable(prim) if _is_projectable_prim(prim) else None
+        if not xformable:
+            result.update(((prim_path, time), None) for time in times)
+            continue
+        ordered_ops = xformable.GetOrderedXformOps()
+        for time in times:
+            result[(prim_path, time)] = as_matrix(
+                xformable.GetLocalTransformation(ordered_ops, _time_code(time))
+            )
     return result
 
 
@@ -337,7 +481,7 @@ def _gprim_values(
     for (prim_path, time), names in candidates.items():
         prim = stage.GetPrimAtPath(prim_path)
         values = {}
-        if prim and prim.IsValid():
+        if _is_projectable_prim(prim):
             time_code = _time_code(time)
             for name in names:
                 attr = prim.GetAttribute(name)
@@ -359,7 +503,12 @@ def _composed_arc_entries(
     from .sdf_arc_state import serialize_reference_custom_data
 
     prim = stage.GetPrimAtPath(prim_path)
-    if not prim or not prim.IsValid():
+    if not _is_projectable_prim(prim):
+        return []
+    if payload:
+        if not prim.HasAuthoredPayloads():
+            return []
+    elif not prim.HasAuthoredReferences():
         return []
     query = Usd.PrimCompositionQuery.GetDirectRootLayerArcs(prim)
     query_filter = query.filter
@@ -408,6 +557,7 @@ class ComposedChangeProjection:
         stage: Usd.Stage,
         events: list[dict],
         *,
+        state: ComposedProjectionState | None = None,
         extra_scene_paths: Iterable[str | Sdf.Path] = (),
         extra_arc_candidates: Iterable[tuple[str, str]] = (),
         reapply_all_composed: bool = False,
@@ -417,7 +567,15 @@ class ComposedChangeProjection:
         self._stage = stage
         self._events = events
         self._validate_events(events)
+        self._state = state or ComposedProjectionState(stage)
+        self._state.bind(stage)
         self._reset = reset
+        self._resynced_paths: set[Sdf.Path] = set()
+        self._changed_info_paths: set[Sdf.Path] = set()
+        self._asset_resync_paths: set[Sdf.Path] = set()
+        self._resync_prim_roots: set[str] = set()
+        self._affected_prim_paths: set[str] = set()
+        self._notice_key = None
         self._prepare_reapplication_scope(
             reapply_all_composed=reapply_all_composed,
             reapply_composed_paths=reapply_composed_paths,
@@ -431,7 +589,34 @@ class ComposedChangeProjection:
             initial_scene_paths,
             extra_arc_candidates,
         )
-        self._before = self._capture_baseline()
+        self._before = self._state.baseline
+        if self._state.needs_full_reconcile:
+            self._resynced_paths.add(Sdf.Path.absoluteRootPath)
+            self._reapply_all_composed = True
+        self._notice_key = Tf.Notice.Register(
+            Usd.Notice.ObjectsChanged,
+            self._on_objects_changed,
+            stage,
+        )
+
+    def __enter__(self) -> ComposedChangeProjection:
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        if _exc_type is not None:
+            self.require_full_reconcile()
+        else:
+            self.close()
+
+    def close(self) -> None:
+        if self._notice_key is not None:
+            self._notice_key.Revoke()
+            self._notice_key = None
+
+    def _on_objects_changed(self, notice, _sender) -> None:
+        self._resynced_paths.update(notice.GetResyncedPaths())
+        self._changed_info_paths.update(notice.GetChangedInfoOnlyPaths())
+        self._asset_resync_paths.update(notice.GetResolvedAssetPathsResyncedPaths())
 
     @staticmethod
     def _validate_events(events: list[dict]) -> None:
@@ -461,12 +646,10 @@ class ComposedChangeProjection:
             for old_path, new_path, _event in self._rename_pairs
             if old_path in self._reapply_composed_paths
         )
-        self._subtree_roots = {
-            str(event["prim"])
-            for event in events
-            if event.get("k") == K_DELETE_PRIM and event.get("prim")
-        }
-        self._subtree_roots.update(path for pair in self._rename_pairs for path in pair[:2])
+        self._subtree_roots = {path for pair in self._rename_pairs for path in pair[:2]}
+        for event in events:
+            if event.get("k") == K_DELETE_PRIM and event.get("prim"):
+                self._subtree_roots.add(str(event["prim"]))
         self._local_lifecycle_paths = (
             {
                 str(event["prim"])
@@ -532,20 +715,132 @@ class ComposedChangeProjection:
     def _capture_baseline(self) -> _ProjectionBaseline:
         stage = self._stage
         candidates = self._candidates
-        return _ProjectionBaseline(
-            valid={path: bool(stage.GetPrimAtPath(path)) for path in candidates.prims},
-            types=self._read_types(candidates.types),
-            xforms=_local_transforms(stage, candidates.xforms),
-            gprim=_gprim_values(stage, candidates.gprim),
-            variants=self._read_variants(candidates.variants),
-            materials=self._read_materials(candidates.materials),
-            connectables=self._read_connectables(candidates.connectables),
-            active=self._read_active(candidates.active),
-            visibility=self._read_visibility(candidates.visibility),
-            instanceable=self._read_instanceable(candidates.instanceable),
-            point_instancers=self._read_point_instancers(candidates.point_instancers),
-            arcs=self._read_arcs(candidates.arcs),
-        )
+        result = _ProjectionBaseline()
+        for prim_path in candidates.prims:
+            result.ensure(prim_path).valid = _is_projectable_prim(
+                stage.GetPrimAtPath(prim_path)
+            )
+        for prim_path, value in self._read_types(candidates.types).items():
+            result.ensure(prim_path).type_state = value
+        for (prim_path, time), value in _local_transforms(
+            stage, candidates.xforms
+        ).items():
+            state = result.ensure(prim_path)
+            if state.xforms is None:
+                state.xforms = {}
+            state.xforms[time] = value
+        for (prim_path, time), values in _gprim_values(stage, candidates.gprim).items():
+            if values:
+                state = result.ensure(prim_path)
+                if state.gprim is None:
+                    state.gprim = {}
+                state.gprim[time] = values
+        for prim_path, values in self._read_variants(candidates.variants).items():
+            if values:
+                result.ensure(prim_path).variants = values
+        for (prim_path, purpose), value in self._read_materials(
+            candidates.materials
+        ).items():
+            if value:
+                state = result.ensure(prim_path)
+                if state.materials is None:
+                    state.materials = {}
+                state.materials[purpose] = value
+        for (prim_path, time), values in self._read_connectables(
+            candidates.connectables
+        ).items():
+            if values.get("info_id") or values.get("inputs") or values.get("connections"):
+                state = result.ensure(prim_path)
+                if state.connectables is None:
+                    state.connectables = {}
+                state.connectables[time] = values
+        for prim_path, value in self._read_active(candidates.active).items():
+            result.ensure(prim_path).active = value
+        for (prim_path, time), value in self._read_visibility(
+            candidates.visibility
+        ).items():
+            state = result.ensure(prim_path)
+            if state.visibility is None:
+                state.visibility = {}
+            state.visibility[time] = value
+        for prim_path, value in self._read_instanceable(candidates.instanceable).items():
+            result.ensure(prim_path).instanceable = value
+        for (prim_path, time), values in self._read_point_instancers(
+            candidates.point_instancers
+        ).items():
+            if values:
+                state = result.ensure(prim_path)
+                if state.point_instancers is None:
+                    state.point_instancers = {}
+                state.point_instancers[time] = values
+        for (prim_path, kind), values in self._read_arcs(candidates.arcs).items():
+            if values:
+                state = result.ensure(prim_path)
+                if state.arcs is None:
+                    state.arcs = {}
+                state.arcs[kind] = values
+        return result
+
+    @classmethod
+    def _capture_scope(
+        cls,
+        stage: Usd.Stage,
+        prim_paths: Iterable[str],
+        *,
+        recurse: bool,
+    ) -> _ProjectionBaseline:
+        """Capture complete adapter-visible state for selected prim scopes."""
+        capture = cls.__new__(cls)
+        capture._stage = stage
+        capture._candidates = _ProjectionCandidates()
+        if recurse:
+            capture._add_subtree_candidates(prim_paths)
+        else:
+            for prim_path in prim_paths:
+                capture._add_prim_candidates(stage.GetPrimAtPath(prim_path))
+        return capture._capture_baseline()
+
+    def _add_baseline_candidates(
+        self,
+        prim_paths: Iterable[str],
+        *,
+        recurse: bool,
+    ) -> None:
+        """Restore pre-change candidates that no longer exist on the stage."""
+        roots = tuple(prim_paths)
+        if not roots:
+            return
+
+        def included(path: str) -> bool:
+            return any(
+                _path_is_at_or_below(path, root) if recurse else path == root for root in roots
+            )
+
+        before = self._before
+        candidates = self._candidates
+        for prim_path, state in before.prims.items():
+            if not included(prim_path):
+                continue
+            candidates.prims.add(prim_path)
+            candidates.types.add(prim_path)
+            candidates.xforms.update((prim_path, time) for time in state.xforms or ())
+            for time, values in (state.gprim or {}).items():
+                candidates.gprim[(prim_path, time)].update(values)
+            if state.variants:
+                candidates.variants.add(prim_path)
+            candidates.materials.update(
+                (prim_path, purpose) for purpose in state.materials or ()
+            )
+            for time in state.connectables or ():
+                candidates.connectables[(prim_path, time)].add("*")
+            candidates.active.add(prim_path)
+            candidates.visibility.update(
+                (prim_path, time) for time in state.visibility or ()
+            )
+            candidates.instanceable.add(prim_path)
+            for time, values in (state.point_instancers or {}).items():
+                candidates.point_instancers[(prim_path, time)].update(values)
+            candidates.arcs.update((prim_path, kind) for kind in state.arcs or ())
 
     def _should_reapply_composed(self, prim_path: str) -> bool:
         return self._reapply_all_composed or prim_path in self._reapply_composed_paths
@@ -648,8 +943,7 @@ class ComposedChangeProjection:
                     name = str(path.name)
                     prim = self._stage.GetPrimAtPath(prim_path)
                     if (
-                        prim
-                        and prim.IsValid()
+                        _is_projectable_prim(prim)
                         and prim.IsA(UsdGeom.PointInstancer)
                         and name in POINT_INSTANCER_USD_TO_WIRE
                     ):
@@ -671,7 +965,9 @@ class ComposedChangeProjection:
                 continue
             path = _sdf_property_path(event)
             prim = self._stage.GetPrimAtPath(prim_path)
-            is_point_instancer = bool(prim and prim.IsValid() and prim.IsA(UsdGeom.PointInstancer))
+            is_point_instancer = bool(
+                _is_projectable_prim(prim) and prim.IsA(UsdGeom.PointInstancer)
+            )
             if path is not None and is_point_instancer:
                 field = POINT_INSTANCER_USD_TO_WIRE.get(str(path.name))
                 if field:
@@ -706,7 +1002,12 @@ class ComposedChangeProjection:
                 result.add((str(event["prim"]), K_SET_PAYLOAD))
         return result
 
-    def _add_scene_path_candidates(self, paths: Iterable[Sdf.Path]) -> None:
+    def _add_scene_path_candidates(
+        self,
+        paths: Iterable[Sdf.Path],
+        *,
+        include_prim_state: bool = True,
+    ) -> None:
         xform_prims = set()
         seen_prims = set()
         for path in paths:
@@ -714,7 +1015,7 @@ class ComposedChangeProjection:
             if not prim_path or prim_path == "/":
                 continue
             prim = None
-            if prim_path not in seen_prims:
+            if include_prim_state and prim_path not in seen_prims:
                 seen_prims.add(prim_path)
                 self._candidates.prims.add(prim_path)
                 self._candidates.types.add(prim_path)
@@ -722,82 +1023,198 @@ class ComposedChangeProjection:
                 self._candidates.active.add(prim_path)
                 self._candidates.instanceable.add(prim_path)
                 prim = self._stage.GetPrimAtPath(prim_path)
-                if prim and prim.IsValid() and prim.IsA(UsdGeom.PointInstancer):
+                if _is_projectable_prim(prim) and prim.IsA(UsdGeom.PointInstancer):
                     self._candidates.point_instancers[(prim_path, None)].add("inactive_ids")
             if not path.IsPropertyPath():
                 continue
 
-            name = str(path.name)
-            if name == "xformOpOrder" or name.startswith("xformOp:"):
-                self._candidates.xforms.add((prim_path, None))
-                xform_prims.add(prim_path)
-                continue
-
             prop = self._stage.GetPropertyAtPath(path)
-            sample_times = tuple(prop.GetTimeSamples()) if isinstance(prop, Usd.Attribute) else ()
-            if name == "visibility":
-                self._candidates.visibility.add((prim_path, None))
-                self._candidates.visibility.update((prim_path, time) for time in sample_times)
-            elif name == "info:id" or name.startswith(("inputs:", "outputs:")):
-                self._candidates.connectables[(prim_path, None)].add(
-                    "*" if name == "info:id" else name
-                )
-                if name.startswith("inputs:"):
-                    for time in sample_times:
-                        self._candidates.connectables[(prim_path, time)].add(name)
-            elif (purpose := _material_purpose_from_name(name)) is not None:
-                self._candidates.materials.add((prim_path, purpose))
-            elif (
-                (prim := prim or self._stage.GetPrimAtPath(prim_path))
-                and prim.IsValid()
-                and prim.IsA(UsdGeom.PointInstancer)
-                and (field := POINT_INSTANCER_USD_TO_WIRE.get(name))
-            ):
-                self._candidates.point_instancers[(prim_path, None)].add(field)
-                for time in sample_times:
-                    self._candidates.point_instancers[(prim_path, time)].add(field)
-            elif _is_gprim_property_name(name):
-                self._candidates.gprim[(prim_path, None)].add(name)
-                for time in sample_times:
-                    self._candidates.gprim[(prim_path, time)].add(name)
+            if self._add_property_candidate(prim_path, str(path.name), prop, prim):
+                xform_prims.add(prim_path)
 
         for prim_path in xform_prims:
             prim = self._stage.GetPrimAtPath(prim_path)
-            xformable = UsdGeom.Xformable(prim) if prim and prim.IsValid() else None
+            xformable = UsdGeom.Xformable(prim) if _is_projectable_prim(prim) else None
             if not xformable:
                 continue
-            sample_times = {
-                time
-                for op in xformable.GetOrderedXformOps()
-                for time in op.GetAttr().GetTimeSamples()
-            }
+            sample_times = xformable.GetTimeSamples()
             self._candidates.xforms.update((prim_path, time) for time in sample_times)
 
+    def _add_property_candidate(
+        self,
+        prim_path: str,
+        name: str,
+        prop: Usd.Property,
+        prim: Usd.Prim | None = None,
+    ) -> bool:
+        """Classify one authored property, returning whether it is an xform op."""
+        candidates = self._candidates
+        if name == "xformOpOrder" or name.startswith("xformOp:"):
+            candidates.xforms.add((prim_path, None))
+            return True
+
+        sample_times = tuple(prop.GetTimeSamples()) if isinstance(prop, Usd.Attribute) else ()
+        if name == "visibility":
+            candidates.visibility.add((prim_path, None))
+            candidates.visibility.update((prim_path, time) for time in sample_times)
+        elif name == "info:id" or name.startswith(("inputs:", "outputs:")):
+            candidates.connectables[(prim_path, None)].add("*" if name == "info:id" else name)
+            if name.startswith("inputs:"):
+                for time in sample_times:
+                    candidates.connectables[(prim_path, time)].add(name)
+        elif (purpose := _material_purpose_from_name(name)) is not None:
+            candidates.materials.add((prim_path, purpose))
+        elif (
+            _is_projectable_prim(prim := prim or self._stage.GetPrimAtPath(prim_path))
+            and prim.IsA(UsdGeom.PointInstancer)
+            and (field := POINT_INSTANCER_USD_TO_WIRE.get(name))
+        ):
+            candidates.point_instancers[(prim_path, None)].add(field)
+            for time in sample_times:
+                candidates.point_instancers[(prim_path, time)].add(field)
+        elif _is_gprim_property_name(name):
+            candidates.gprim[(prim_path, None)].add(name)
+            for time in sample_times:
+                candidates.gprim[(prim_path, time)].add(name)
+        return False
+
+    def _add_prim_candidates(self, prim: Usd.Prim) -> None:
+        if not _is_projectable_prim(prim):
+            return
+        prim_path = str(prim.GetPath())
+        candidates = self._candidates
+        candidates.prims.add(prim_path)
+        candidates.types.add(prim_path)
+        candidates.variants.add(prim_path)
+        candidates.active.add(prim_path)
+        candidates.instanceable.add(prim_path)
+        is_point_instancer = prim.IsA(UsdGeom.PointInstancer)
+        if is_point_instancer:
+            candidates.point_instancers[(prim_path, None)].add("inactive_ids")
+        if prim.HasAuthoredReferences():
+            candidates.arcs.add((prim_path, K_SET_REFERENCE))
+        if prim.HasAuthoredPayloads():
+            candidates.arcs.add((prim_path, K_SET_PAYLOAD))
+
+        has_xform = False
+        for prop in prim.GetAuthoredProperties():
+            has_xform |= self._add_property_candidate(
+                prim_path,
+                str(prop.GetName()),
+                prop,
+                prim,
+            )
+        if has_xform:
+            xformable = UsdGeom.Xformable(prim)
+            candidates.xforms.update(
+                (prim_path, time) for time in xformable.GetTimeSamples()
+            )
+
     def _add_subtree_candidates(self, roots: Iterable[str]) -> None:
-        paths = []
         for root in roots:
-            prim = self._stage.GetPrimAtPath(root)
+            prim = (
+                self._stage.GetPseudoRoot() if str(root) == "/" else self._stage.GetPrimAtPath(root)
+            )
             if not prim or not prim.IsValid():
                 continue
             for descendant in Usd.PrimRange.AllPrims(prim):
-                paths.append(descendant.GetPath())
-                self._candidates.arcs.update(
-                    (str(descendant.GetPath()), kind) for kind in (K_SET_REFERENCE, K_SET_PAYLOAD)
-                )
-                paths.extend(prop.GetPath() for prop in descendant.GetAuthoredProperties())
-        self._add_scene_path_candidates(paths)
+                self._add_prim_candidates(descendant)
+
+    @staticmethod
+    def _minimal_roots(paths: Iterable[str]) -> set[str]:
+        result: list[str] = []
+        for path in sorted(set(paths), key=lambda item: (item.count("/"), item)):
+            if any(_path_is_at_or_below(path, root) for root in result):
+                continue
+            result.append(path)
+        return set(result)
+
+    @staticmethod
+    def _notice_prim_path(path: Sdf.Path) -> str | None:
+        if path == Sdf.Path.absoluteRootPath:
+            return "/"
+        prim_path = path if path.IsPrimPath() else path.GetPrimPath()
+        return str(prim_path) if prim_path and prim_path != Sdf.Path.absoluteRootPath else None
+
+    def _add_notice_candidates(self) -> None:
+        subtree_roots = set(self._subtree_roots)
+        exact_paths: set[str] = set()
+        exact_scene_paths: set[Sdf.Path] = set()
+
+        for path in self._resynced_paths | self._asset_resync_paths:
+            prim_path = self._notice_prim_path(path)
+            if prim_path is None:
+                continue
+            if path == Sdf.Path.absoluteRootPath or path.IsPrimPath():
+                subtree_roots.add(prim_path)
+            else:
+                exact_paths.add(prim_path)
+                exact_scene_paths.add(path)
+
+        for path in self._changed_info_paths:
+            if prim_path := self._notice_prim_path(path):
+                exact_paths.add(prim_path)
+            exact_scene_paths.add(path)
+
+        self._resync_prim_roots = self._minimal_roots(subtree_roots)
+        exact_paths = {
+            path
+            for path in exact_paths
+            if not any(_path_is_at_or_below(path, root) for root in self._resync_prim_roots)
+        }
+
+        self._add_baseline_candidates(self._resync_prim_roots, recurse=True)
+        self._add_subtree_candidates(self._resync_prim_roots)
+        prim_scene_paths = {path for path in exact_scene_paths if not path.IsPropertyPath()}
+        property_scene_paths = exact_scene_paths - prim_scene_paths
+        self._add_scene_path_candidates(prim_scene_paths)
+        self._add_scene_path_candidates(
+            property_scene_paths,
+            include_prim_state=False,
+        )
+
+    def _record_affected_prim_paths(self) -> None:
+        candidates = self._candidates
+        paths = set(candidates.prims) | set(candidates.types)
+        paths.update(key[0] for key in candidates.xforms)
+        paths.update(key[0] for key in candidates.gprim)
+        paths.update(candidates.variants)
+        paths.update(key[0] for key in candidates.materials)
+        paths.update(key[0] for key in candidates.connectables)
+        paths.update(candidates.active)
+        paths.update(key[0] for key in candidates.visibility)
+        paths.update(candidates.instanceable)
+        paths.update(key[0] for key in candidates.point_instancers)
+        paths.update(key[0] for key in candidates.arcs)
+        self._affected_prim_paths = {path for path in paths if path and path != "/"}
+
+    def _before_state(self, prim_path: str) -> _PrimProjectionBaseline:
+        return self._before.prims.get(prim_path, _EMPTY_PRIM_BASELINE)
 
     def build_events(self) -> list[dict]:
         """Return adapter events representing the post-transaction composition."""
+        self.close()
+        self._add_notice_candidates()
         if self._event_scene_paths:
             self._add_scene_path_candidates(self._event_scene_paths)
         if self._subtree_roots:
             self._add_subtree_candidates(self._subtree_roots)
+        self._record_affected_prim_paths()
 
         projected: list[dict] = []
         for step in _PROJECTION_STEPS:
             projected.extend(getattr(self, step.method_name)())
         return projected
+
+    def commit(self) -> None:
+        """Record that the projected events reached the native adapter."""
+        self.close()
+        self._state.commit(self)
+
+    def require_full_reconcile(self) -> None:
+        """Preserve the adapter baseline and widen the next transaction."""
+        self.close()
+        self._state.require_full_reconcile()
 
     def _project_namespace_and_lifecycle(self) -> list[dict]:
         renames = self._project_renames()
@@ -829,7 +1246,7 @@ class ComposedChangeProjection:
         after = self._read_arcs(self._candidates.arcs)
         result = []
         for (prim_path, kind), entries in after.items():
-            before = self._before.arcs.get((prim_path, kind), [])
+            before = (self._before_state(prim_path).arcs or {}).get(kind, [])
             reapply_composed = self._should_reapply_composed(prim_path)
             if entries == before and not reapply_composed:
                 continue
@@ -856,7 +1273,7 @@ class ComposedChangeProjection:
             prim = self._stage.GetPrimAtPath(prim_path)
             result[prim_path] = (
                 (str(prim.GetTypeName()), tuple(prim.GetAppliedSchemas()))
-                if prim and prim.IsValid()
+                if _is_projectable_prim(prim)
                 else None
             )
         return result
@@ -864,11 +1281,11 @@ class ComposedChangeProjection:
     def _project_renames(self) -> list[tuple[str, str, dict]]:
         result = []
         for old_path, new_path, event in self._rename_pairs:
-            old_after = bool(self._stage.GetPrimAtPath(old_path))
-            new_after = bool(self._stage.GetPrimAtPath(new_path))
+            old_after = _is_projectable_prim(self._stage.GetPrimAtPath(old_path))
+            new_after = _is_projectable_prim(self._stage.GetPrimAtPath(new_path))
             if (
-                self._before.valid.get(old_path, False)
-                and not self._before.valid.get(new_path, False)
+                self._before_state(old_path).valid
+                and not self._before_state(new_path).valid
                 and not old_after
                 and new_after
             ):
@@ -890,9 +1307,10 @@ class ComposedChangeProjection:
             if prim_path in renamed_paths:
                 continue
             prim = self._stage.GetPrimAtPath(prim_path)
-            valid_after = bool(prim)
-            valid_before = self._before.valid.get(prim_path, False)
-            before_type = self._before.types.get(prim_path)
+            valid_after = _is_projectable_prim(prim)
+            before_state = self._before_state(prim_path)
+            valid_before = before_state.valid
+            before_type = before_state.type_state
             after_type = types_after.get(prim_path)
             type_changed = bool(
                 valid_before
@@ -906,7 +1324,7 @@ class ComposedChangeProjection:
                 and not self._reset
                 and prim_path in self._local_lifecycle_paths
             )
-            schema_changed = before_type != after_type
+            schema_changed = prim_path in self._candidates.types and before_type != after_type
             ensure = {
                 "k": K_ENSURE_PRIM,
                 "prim": prim_path,
@@ -933,9 +1351,9 @@ class ComposedChangeProjection:
         result = []
         for (prim_path, time), values in after.items():
             prim = self._stage.GetPrimAtPath(prim_path)
-            if not prim or not prim.IsValid():
+            if not _is_projectable_prim(prim):
                 continue
-            before = self._before.gprim.get((prim_path, time), {})
+            before = (self._before_state(prim_path).gprim or {}).get(time, {})
             selected = {
                 name: value
                 for name, value in values.items()
@@ -1003,9 +1421,9 @@ class ComposedChangeProjection:
         result = []
         for key, values in after.items():
             prim = self._stage.GetPrimAtPath(key[0])
-            if not prim or not prim.IsValid() or not prim.IsA(UsdGeom.PointInstancer):
+            if not _is_projectable_prim(prim) or not prim.IsA(UsdGeom.PointInstancer):
                 continue
-            before = self._before.point_instancers.get(key, {})
+            before = (self._before_state(key[0]).point_instancers or {}).get(key[1], {})
             fields = sorted(
                 field
                 for field in self._candidates.point_instancers[key]
@@ -1040,9 +1458,9 @@ class ComposedChangeProjection:
         after = self._read_variants(self._candidates.variants)
         result = []
         for prim_path, selections in after.items():
-            if not self._stage.GetPrimAtPath(prim_path):
+            if not _is_projectable_prim(self._stage.GetPrimAtPath(prim_path)):
                 continue
-            before = self._before.variants.get(prim_path, {})
+            before = self._before_state(prim_path).variants or {}
             if not self._should_reapply_composed(prim_path) and selections == before:
                 continue
             projected = dict(selections)
@@ -1074,11 +1492,12 @@ class ComposedChangeProjection:
         after = self._read_materials(self._candidates.materials)
         result = []
         for key, material_path in after.items():
-            if not self._stage.GetPrimAtPath(key[0]):
+            if not _is_projectable_prim(self._stage.GetPrimAtPath(key[0])):
                 continue
             if (
                 not self._should_reapply_composed(key[0])
-                and self._before.materials.get(key, "") == material_path
+                and (self._before_state(key[0]).materials or {}).get(key[1], "")
+                == material_path
             ):
                 continue
             prim_path, purpose = key
@@ -1124,6 +1543,14 @@ class ComposedChangeProjection:
         for key, local_attrs in candidates.items():
             prim_path, time = key
             prim = self._stage.GetPrimAtPath(prim_path)
+            if not _is_projectable_prim(prim):
+                result[key] = {
+                    "info_id": "",
+                    "inputs": {},
+                    "types": {},
+                    "connections": {},
+                }
+                continue
             container_kind = connectable_kind(prim)
             state = {
                 "info_id": "",
@@ -1166,6 +1593,7 @@ class ComposedChangeProjection:
                     self._stage,
                     prim_path,
                 )
+                connections.update(state["connections"])
                 state = {
                     "info_id": info_id,
                     "inputs": inputs,
@@ -1187,9 +1615,9 @@ class ComposedChangeProjection:
         input_events = []
         connection_events = []
         for key, state in after.items():
-            if not self._stage.GetPrimAtPath(key[0]):
+            if not _is_projectable_prim(self._stage.GetPrimAtPath(key[0])):
                 continue
-            before = self._before.connectables.get(key, {})
+            before = (self._before_state(key[0]).connectables or {}).get(key[1], {})
             previous_inputs = before.get("inputs", {})
             changed_inputs = {
                 name: value
@@ -1237,7 +1665,7 @@ class ComposedChangeProjection:
         result = {}
         for prim_path in prim_paths:
             prim = self._stage.GetPrimAtPath(prim_path)
-            result[prim_path] = prim.IsActive() if prim and prim.IsValid() else None
+            result[prim_path] = prim.IsActive() if _is_projectable_prim(prim) else None
         return result
 
     def _project_active(self) -> list[dict]:
@@ -1250,9 +1678,10 @@ class ComposedChangeProjection:
             }
             for prim_path, active in after.items()
             if active is not None
+            and (active is False or self._before_state(prim_path).active is not None)
             and (
                 self._should_reapply_composed(prim_path)
-                or self._before.active.get(prim_path) != active
+                or self._before_state(prim_path).active != active
             )
         ]
 
@@ -1263,7 +1692,7 @@ class ComposedChangeProjection:
         result = {}
         for key in candidates:
             prim = self._stage.GetPrimAtPath(key[0])
-            imageable = UsdGeom.Imageable(prim) if prim and prim.IsValid() else None
+            imageable = UsdGeom.Imageable(prim) if _is_projectable_prim(prim) else None
             if not imageable:
                 result[key] = None
                 continue
@@ -1277,7 +1706,7 @@ class ComposedChangeProjection:
         for key, visible in after.items():
             if visible is None or (
                 not self._should_reapply_composed(key[0])
-                and self._before.visibility.get(key) == visible
+                and (self._before_state(key[0]).visibility or {}).get(key[1]) == visible
             ):
                 continue
             event = {
@@ -1294,7 +1723,7 @@ class ComposedChangeProjection:
         result = {}
         for prim_path in prim_paths:
             prim = self._stage.GetPrimAtPath(prim_path)
-            result[prim_path] = prim.IsInstanceable() if prim and prim.IsValid() else None
+            result[prim_path] = prim.IsInstanceable() if _is_projectable_prim(prim) else None
         return result
 
     def _project_instanceable(self) -> list[dict]:
@@ -1308,8 +1737,12 @@ class ComposedChangeProjection:
             for prim_path, instanceable in after.items()
             if instanceable is not None
             and (
+                instanceable is True
+                or self._before_state(prim_path).instanceable is not None
+            )
+            and (
                 self._should_reapply_composed(prim_path)
-                or self._before.instanceable.get(prim_path) != instanceable
+                or self._before_state(prim_path).instanceable != instanceable
             )
         ]
 
@@ -1328,12 +1761,12 @@ class ComposedChangeProjection:
         ):
             prim_path, time = key
             prim = self._stage.GetPrimAtPath(prim_path)
-            if not prim or not prim.IsValid():
+            if not _is_projectable_prim(prim):
                 continue
             xformable = UsdGeom.Xformable(prim)
             if not xformable:
                 continue
-            changed = self._before.xforms.get(key) != after.get(key)
+            changed = (self._before_state(prim_path).xforms or {}).get(time) != after.get(key)
             reapply_composed = self._should_reapply_composed(prim_path)
             if not (reapply_composed or changed or prim_path in ensure_ops):
                 continue
@@ -1374,6 +1807,7 @@ class ComposedChangeProjection:
             raise RuntimeError(f"event kind has no native projection policy: {kind!r}")
         return result
 
+
 def _validate_projection_steps() -> None:
     candidate_names = _ProjectionCandidates.__dataclass_fields__
     for step in _PROJECTION_STEPS:
@@ -1390,12 +1824,11 @@ def _validate_projection_steps() -> None:
             )
         if not hasattr(ComposedChangeProjection, step.collector_name):
             raise RuntimeError(
-                f"native projection step {step.name!r} has no collector "
-                f"{step.collector_name!r}"
+                f"native projection step {step.name!r} has no collector {step.collector_name!r}"
             )
 
 
 _validate_projection_steps()
 
 
-__all__ = ["ComposedChangeProjection"]
+__all__ = ["ComposedChangeProjection", "ComposedProjectionState"]

--- a/openusdconnect/composed_projection.py
+++ b/openusdconnect/composed_projection.py
@@ -7,8 +7,9 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import cast
+from weakref import ref
 
-from pxr import Sdf, Tf, Usd, UsdGeom, UsdShade
+from pxr import Ar, Sdf, Tf, Usd, UsdGeom, UsdShade, UsdUtils
 
 from .protocol_constants import (
     EVENT_KEYS,
@@ -80,8 +81,8 @@ class _ProjectionCandidates:
 
 
 @dataclass(slots=True)
-class _PrimProjectionBaseline:
-    """Adapter-visible state retained for one composed prim."""
+class _PrimProjectionValues:
+    """Adapter-visible values read for one affected composed prim."""
 
     valid: bool = False
     type_state: tuple[str, tuple[str, ...]] | None = None
@@ -98,20 +99,20 @@ class _PrimProjectionBaseline:
 
 
 @dataclass(slots=True)
-class _ProjectionBaseline:
-    """Selected composed state captured immediately before a transaction."""
+class _ProjectionValues:
+    """Selected composed values read from one side of a transaction."""
 
-    prims: dict[str, _PrimProjectionBaseline] = dataclass_field(default_factory=dict)
+    prims: dict[str, _PrimProjectionValues] = dataclass_field(default_factory=dict)
 
-    def ensure(self, prim_path: str) -> _PrimProjectionBaseline:
+    def ensure(self, prim_path: str) -> _PrimProjectionValues:
         state = self.prims.get(prim_path)
         if state is None:
-            state = _PrimProjectionBaseline()
+            state = _PrimProjectionValues()
             self.prims[prim_path] = state
         return state
 
 
-_EMPTY_PRIM_BASELINE = _PrimProjectionBaseline()
+_EMPTY_PRIM_VALUES = _PrimProjectionValues()
 
 
 def _path_is_at_or_below(path: str, root: str) -> bool:
@@ -135,6 +136,208 @@ def _is_projectable_prim(prim: Usd.Prim) -> bool:
     return bool(prim.GetTypeName() or prim.GetAuthoredProperties() or not tuple(prim.GetChildren()))
 
 
+class _OwnedStageShadow:
+    """Independent shadow for callers without an externally managed stage.
+
+    All-anonymous root/session sublayer trees are cloned exactly with
+    ``TransferContent`` and identifier rewiring. File-backed local layers use
+    ``UsdUtils.FlattenLayerStack`` so relative asset paths retain their source
+    anchors while references, payloads, inherits, specializes, and variants
+    remain composition arcs.
+    """
+
+    def __init__(self, live_stage: Usd.Stage):
+        self._live_stage = live_stage
+        self._stage: Usd.Stage | None = None
+        self._sources: dict[str, Sdf.Layer] = {}
+        self._clones: dict[str, Sdf.Layer] = {}
+        self._flattened = False
+        self._rebuild()
+
+    @property
+    def stage(self) -> Usd.Stage:
+        if self._stage is None:
+            raise RuntimeError("owned projection shadow is closed")
+        return self._stage
+
+    @staticmethod
+    def _resolve_sublayer(layer: Sdf.Layer, path: str) -> Sdf.Layer | None:
+        return Sdf.Layer.FindRelativeToLayer(
+            layer,
+            path,
+        ) or Sdf.Layer.FindOrOpenRelativeToLayer(layer, path)
+
+    @classmethod
+    def _collect_local_layers(cls, stage: Usd.Stage) -> dict[str, Sdf.Layer]:
+        result: dict[str, Sdf.Layer] = {}
+
+        def collect(layer: Sdf.Layer) -> None:
+            if layer.identifier in result:
+                return
+            result[layer.identifier] = layer
+            for path in layer.subLayerPaths:
+                child = cls._resolve_sublayer(layer, path)
+                if child is not None:
+                    collect(child)
+
+        collect(stage.GetRootLayer())
+        collect(stage.GetSessionLayer())
+        return result
+
+    @staticmethod
+    def _clone_layer(source: Sdf.Layer) -> Sdf.Layer:
+        extension = source.GetFileFormat().primaryFileExtension or "usda"
+        clone = Sdf.Layer.CreateAnonymous(f"projection-shadow.{extension}")
+        clone.TransferContent(source)
+        return clone
+
+    @staticmethod
+    def _freeze_asset_path(source_layer: Sdf.Layer, asset_path: str) -> str:
+        """Keep resolver-dependent paths fixed at their current resolution."""
+        anchored = UsdUtils.FlattenLayerStackResolveAssetPath(
+            source_layer,
+            asset_path,
+        )
+        resolver = Ar.GetResolver()
+        if not (
+            resolver.IsContextDependentPath(asset_path)
+            or resolver.IsContextDependentPath(anchored)
+        ):
+            return anchored
+        resolved = resolver.Resolve(anchored)
+        return str(resolved) if resolved else anchored
+
+    def _rewire_sublayers(self) -> None:
+        for identifier, source in self._sources.items():
+            clone = self._clones[identifier]
+            for index, path in enumerate(tuple(source.subLayerPaths)):
+                child = self._resolve_sublayer(source, path)
+                if child is None:
+                    continue
+                child_clone = self._clones.get(child.identifier)
+                if child_clone is not None:
+                    clone.subLayerPaths[index] = child_clone.identifier
+
+    def _mapped_muted_layers(self) -> set[str]:
+        return {
+            self._clones[identifier].identifier
+            if identifier in self._clones
+            else identifier
+            for identifier in self._live_stage.GetMutedLayers()
+        }
+
+    def _sync_runtime_state(self) -> None:
+        shadow = self.stage
+        live = self._live_stage
+        population_mask = live.GetPopulationMask()
+        if shadow.GetPopulationMask() != population_mask:
+            shadow.SetPopulationMask(population_mask)
+
+        load_rules = live.GetLoadRules()
+        if shadow.GetLoadRules() != load_rules:
+            shadow.SetLoadRules(load_rules)
+        if self._flattened:
+            return
+
+        desired_muted = self._mapped_muted_layers()
+        current_muted = set(shadow.GetMutedLayers())
+        to_mute = sorted(desired_muted - current_muted)
+        to_unmute = sorted(current_muted - desired_muted)
+        if to_mute or to_unmute:
+            shadow.MuteAndUnmuteLayers(to_mute, to_unmute)
+
+    def prepare(self) -> None:
+        """Follow runtime mask/load changes without advancing authored state."""
+        self._sync_runtime_state()
+
+    def advance(self, projected_events: list[dict] | None) -> None:
+        """Advance native-visible state after adapter success.
+
+        File-backed shadows are already a consolidated local layer stack, so
+        the projected adapter batch is their cheapest exact advancement. A
+        caller that commits without building events falls back to rebuilding.
+        """
+        if self._flattened:
+            if projected_events is None:
+                self._rebuild()
+                return
+            from .adapters import UsdStageAdapter
+
+            shadow = self.stage
+            if not projected_events:
+                self._sync_runtime_state()
+                return
+            try:
+                with Usd.EditContext(shadow, shadow.GetRootLayer()):
+                    UsdStageAdapter(shadow).apply_events(projected_events)
+                self._sync_runtime_state()
+            except Exception:
+                self._rebuild()
+            return
+
+        current_sources = self._collect_local_layers(self._live_stage)
+        if set(current_sources) != set(self._sources):
+            self._rebuild(current_sources)
+            return
+
+        self._sources = current_sources
+        with Sdf.ChangeBlock():
+            for identifier, source in self._sources.items():
+                self._clones[identifier].TransferContent(source)
+            self._rewire_sublayers()
+        self._sync_runtime_state()
+
+    def _rebuild(self, sources: dict[str, Sdf.Layer] | None = None) -> None:
+        live = self._live_stage
+        self._stage = None
+        self._sources = sources or self._collect_local_layers(live)
+        self._flattened = any(not layer.anonymous for layer in self._sources.values())
+        if self._flattened:
+            root = UsdUtils.FlattenLayerStack(
+                live,
+                resolveAssetPathFn=self._freeze_asset_path,
+            )
+            session = Sdf.Layer.CreateAnonymous("projection-shadow-session.usda")
+            shadow = Usd.Stage.OpenMasked(
+                root,
+                session,
+                live.GetPathResolverContext(),
+                live.GetPopulationMask(),
+                Usd.Stage.LoadNone,
+            )
+            if shadow is None:
+                raise RuntimeError("could not open flattened local-stack projection shadow")
+            self._clones = {}
+            self._stage = shadow
+            self._sync_runtime_state()
+            return
+
+        self._clones = {
+            identifier: self._clone_layer(source)
+            for identifier, source in self._sources.items()
+        }
+        self._rewire_sublayers()
+        root = self._clones[live.GetRootLayer().identifier]
+        session = self._clones[live.GetSessionLayer().identifier]
+        shadow = Usd.Stage.OpenMasked(
+            root,
+            session,
+            live.GetPathResolverContext(),
+            live.GetPopulationMask(),
+            Usd.Stage.LoadNone,
+        )
+        if shadow is None:
+            raise RuntimeError("could not open owned projection shadow stage")
+        self._stage = shadow
+        self._sync_runtime_state()
+
+    def close(self) -> None:
+        self._stage = None
+        self._sources.clear()
+        self._clones.clear()
+        self._flattened = False
+
+
 class ComposedProjectionState:
     """Last successfully applied native-visible state for one mirror stage.
 
@@ -143,8 +346,10 @@ class ComposedProjectionState:
     those post-change paths diffable without accessing the private Pcp cache,
     scanning every prim, or retaining a Python snapshot of the whole stage.
 
-    The snapshot fallback remains available for standalone callers that do
-    not supply ``shadow_stage``. Layered dispatch uses the shadow path.
+    Layered dispatch supplies its incrementally-replayed shadow. Standalone
+    callers receive an owned shadow with independent clones of the editable
+    root/session sublayer trees. File-backed local stacks use OpenUSD's native
+    layer-stack flattening so relative asset paths remain correctly anchored.
     """
 
     def __init__(
@@ -157,7 +362,9 @@ class ComposedProjectionState:
         self._stage: Usd.Stage | None = None
         self._shadow_stage: Usd.Stage | None = None
         self._advance_shadow: Callable[[], None] | None = None
-        self._baseline: _ProjectionBaseline | None = None
+        self._owned_shadow: _OwnedStageShadow | None = None
+        self._resolver_notice_key = None
+        self._resolver_notice_callback = None
         self._needs_full_reconcile = False
         if stage is not None:
             self.bind(
@@ -165,14 +372,6 @@ class ComposedProjectionState:
                 shadow_stage=shadow_stage,
                 advance_shadow=advance_shadow,
             )
-
-    @property
-    def baseline(self) -> _ProjectionBaseline:
-        if self._baseline is None:
-            if self._shadow_stage is not None:
-                raise RuntimeError("snapshot baseline is unavailable in shadow mode")
-            raise RuntimeError("composed projection state is not bound")
-        return self._baseline
 
     @property
     def needs_full_reconcile(self) -> bool:
@@ -184,7 +383,35 @@ class ComposedProjectionState:
 
     @property
     def shadow_stage(self) -> Usd.Stage | None:
+        if self._owned_shadow is not None:
+            return self._owned_shadow.stage
         return self._shadow_stage
+
+    def _on_resolver_changed(self, notice, _sender) -> None:
+        stage = self._stage
+        if stage is not None and notice.AffectsContext(stage.GetPathResolverContext()):
+            self.require_full_reconcile()
+
+    def _ensure_resolver_listener(self) -> None:
+        if self._resolver_notice_key is None:
+            state_ref = ref(self)
+
+            def on_resolver_changed(notice, sender) -> None:
+                state = state_ref()
+                if state is not None:
+                    state._on_resolver_changed(notice, sender)
+
+            self._resolver_notice_callback = on_resolver_changed
+            self._resolver_notice_key = Tf.Notice.RegisterGlobally(
+                Ar.Notice.ResolverChanged,
+                self._resolver_notice_callback,
+            )
+
+    def prepare(self, stage: Usd.Stage) -> None:
+        if self._stage is not stage:
+            self.bind(stage)
+        elif self._owned_shadow is not None:
+            self._owned_shadow.prepare()
 
     def bind(
         self,
@@ -193,6 +420,7 @@ class ComposedProjectionState:
         shadow_stage: Usd.Stage | None = None,
         advance_shadow: Callable[[], None] | None = None,
     ) -> None:
+        self._ensure_resolver_listener()
         if stage is self._stage and shadow_stage is None and advance_shadow is None:
             return
         if shadow_stage is stage:
@@ -202,30 +430,32 @@ class ComposedProjectionState:
         if (
             stage is self._stage
             and shadow_stage is self._shadow_stage
-            and (shadow_stage is not None or self._baseline is not None)
+            and shadow_stage is not None
         ):
             self._advance_shadow = advance_shadow
             return
+        if self._owned_shadow is not None:
+            self._owned_shadow.close()
         self._stage = stage
         self._shadow_stage = shadow_stage
         self._advance_shadow = advance_shadow
-        self._baseline = (
-            None
-            if shadow_stage is not None
-            else ComposedChangeProjection._capture_scope(
-                stage,
-                ("/",),
-                recurse=True,
-            )
+        self._owned_shadow = (
+            _OwnedStageShadow(stage) if shadow_stage is None else None
         )
         self._needs_full_reconcile = False
 
     def close(self) -> None:
+        if self._owned_shadow is not None:
+            self._owned_shadow.close()
         self._stage = None
         self._shadow_stage = None
         self._advance_shadow = None
-        self._baseline = None
+        self._owned_shadow = None
         self._needs_full_reconcile = False
+        if self._resolver_notice_key is not None:
+            self._resolver_notice_key.Revoke()
+            self._resolver_notice_key = None
+            self._resolver_notice_callback = None
 
     def require_full_reconcile(self) -> None:
         """Keep the last adapter baseline but widen the next projection."""
@@ -240,55 +470,14 @@ class ComposedProjectionState:
         if stage is not self._stage:
             raise ValueError("projection stage no longer matches persistent state")
 
-        if self._shadow_stage is not None:
+        if self._owned_shadow is not None:
+            self._owned_shadow.advance(projection._projected_events)
+        elif self._shadow_stage is not None:
             if self._advance_shadow is None:
                 raise RuntimeError("shadow projection state cannot advance")
             self._advance_shadow()
-            self._needs_full_reconcile = False
-            return
-
-        subtree_roots = set(projection._resync_prim_roots)
-        exact_paths = set(projection._affected_prim_paths)
-        exact_paths = {
-            path
-            for path in exact_paths
-            if not any(_path_is_at_or_below(path, root) for root in subtree_roots)
-        }
-
-        if not subtree_roots and not exact_paths:
-            self._needs_full_reconcile = False
-            return
-
-        if "/" in subtree_roots:
-            self._baseline = ComposedChangeProjection._capture_scope(
-                stage,
-                ("/",),
-                recurse=True,
-            )
-            self._needs_full_reconcile = False
-            return
-
-        if subtree_roots:
-            removed_paths = {
-                path
-                for path in self.baseline.prims
-                if any(_path_is_at_or_below(path, root) for root in subtree_roots)
-            }
-            for path in removed_paths:
-                self.baseline.prims.pop(path, None)
-            self.baseline.prims.update(
-                ComposedChangeProjection._capture_scope(
-                    stage, subtree_roots, recurse=True
-                ).prims
-            )
-        if exact_paths:
-            for path in exact_paths:
-                self.baseline.prims.pop(path, None)
-            self.baseline.prims.update(
-                ComposedChangeProjection._capture_scope(
-                    stage, exact_paths, recurse=False
-                ).prims
-            )
+        else:
+            raise RuntimeError("composed projection state has no shadow")
         self._needs_full_reconcile = False
 
 
@@ -625,14 +814,14 @@ class ComposedChangeProjection:
         self._events = events
         self._validate_events(events)
         self._state = state or ComposedProjectionState(stage)
-        if self._state.stage is not stage:
-            self._state.bind(stage)
+        self._state.prepare(stage)
         self._reset = reset
         self._resynced_paths: set[Sdf.Path] = set()
         self._changed_info_paths: set[Sdf.Path] = set()
         self._asset_resync_paths: set[Sdf.Path] = set()
         self._resync_prim_roots: set[str] = set()
         self._affected_prim_paths: set[str] = set()
+        self._projected_events: list[dict] | None = None
         self._notice_key = None
         self._prepare_reapplication_scope(
             reapply_all_composed=reapply_all_composed,
@@ -647,9 +836,7 @@ class ComposedChangeProjection:
             initial_scene_paths,
             extra_arc_candidates,
         )
-        self._before = (
-            None if self._state.shadow_stage is not None else self._state.baseline
-        )
+        self._before: _ProjectionValues | None = None
         if self._state.needs_full_reconcile:
             self._resynced_paths.add(Sdf.Path.absoluteRootPath)
             self._reapply_all_composed = True
@@ -772,10 +959,10 @@ class ComposedChangeProjection:
         self._add_scene_path_candidates(scene_paths)
         self._add_subtree_candidates(self._subtree_roots)
 
-    def _capture_baseline(self) -> _ProjectionBaseline:
+    def _capture_candidate_values(self) -> _ProjectionValues:
         stage = self._stage
         candidates = self._candidates
-        result = _ProjectionBaseline()
+        result = _ProjectionValues()
         for prim_path in candidates.prims:
             result.ensure(prim_path).valid = _is_projectable_prim(
                 stage.GetPrimAtPath(prim_path)
@@ -846,74 +1033,11 @@ class ComposedChangeProjection:
         cls,
         stage: Usd.Stage,
         candidates: _ProjectionCandidates,
-    ) -> _ProjectionBaseline:
+    ) -> _ProjectionValues:
         capture = cls.__new__(cls)
         capture._stage = stage
         capture._candidates = candidates
-        return capture._capture_baseline()
-
-    @classmethod
-    def _capture_scope(
-        cls,
-        stage: Usd.Stage,
-        prim_paths: Iterable[str],
-        *,
-        recurse: bool,
-    ) -> _ProjectionBaseline:
-        """Capture complete adapter-visible state for selected prim scopes."""
-        capture = cls.__new__(cls)
-        capture._stage = stage
-        capture._candidates = _ProjectionCandidates()
-        if recurse:
-            capture._add_subtree_candidates(prim_paths)
-        else:
-            for prim_path in prim_paths:
-                capture._add_prim_candidates(stage.GetPrimAtPath(prim_path))
-        return cls._capture_candidates(stage, capture._candidates)
-
-    def _add_baseline_candidates(
-        self,
-        prim_paths: Iterable[str],
-        *,
-        recurse: bool,
-    ) -> None:
-        """Restore pre-change candidates that no longer exist on the stage."""
-        roots = tuple(prim_paths)
-        if not roots:
-            return
-
-        def included(path: str) -> bool:
-            return any(
-                _path_is_at_or_below(path, root) if recurse else path == root for root in roots
-            )
-
-        before = self._before
-        if before is None:
-            raise RuntimeError("snapshot baseline is unavailable in shadow mode")
-        candidates = self._candidates
-        for prim_path, state in before.prims.items():
-            if not included(prim_path):
-                continue
-            candidates.prims.add(prim_path)
-            candidates.types.add(prim_path)
-            candidates.xforms.update((prim_path, time) for time in state.xforms or ())
-            for time, values in (state.gprim or {}).items():
-                candidates.gprim[(prim_path, time)].update(values)
-            if state.variants:
-                candidates.variants.add(prim_path)
-            candidates.materials.update(
-                (prim_path, purpose) for purpose in state.materials or ()
-            )
-            for time in state.connectables or ():
-                candidates.connectables[(prim_path, time)].add("*")
-            candidates.active.add(prim_path)
-            candidates.visibility.update(
-                (prim_path, time) for time in state.visibility or ()
-            )
-            candidates.instanceable.add(prim_path)
-            for time, values in (state.point_instancers or {}).items():
-                candidates.point_instancers[(prim_path, time)].update(values)
-            candidates.arcs.update((prim_path, kind) for kind in state.arcs or ())
+        return capture._capture_candidate_values()
 
     def _should_reapply_composed(self, prim_path: str) -> bool:
         return self._reapply_all_composed or prim_path in self._reapply_composed_paths
@@ -1263,12 +1387,11 @@ class ComposedChangeProjection:
 
         before_stage = self._state.shadow_stage
         if before_stage is None:
-            self._add_baseline_candidates(self._resync_prim_roots, recurse=True)
-        else:
-            self._add_subtree_candidates(
-                self._resync_prim_roots,
-                stage=before_stage,
-            )
+            raise RuntimeError("composed projection state has no shadow stage")
+        self._add_subtree_candidates(
+            self._resync_prim_roots,
+            stage=before_stage,
+        )
         self._add_subtree_candidates(self._resync_prim_roots)
         prim_scene_paths = {path for path in exact_scene_paths if not path.IsPropertyPath()}
         property_scene_paths = exact_scene_paths - prim_scene_paths
@@ -1277,16 +1400,15 @@ class ComposedChangeProjection:
             property_scene_paths,
             include_prim_state=False,
         )
-        if before_stage is not None:
-            self._add_scene_path_candidates(
-                prim_scene_paths,
-                stage=before_stage,
-            )
-            self._add_scene_path_candidates(
-                property_scene_paths,
-                include_prim_state=False,
-                stage=before_stage,
-            )
+        self._add_scene_path_candidates(
+            prim_scene_paths,
+            stage=before_stage,
+        )
+        self._add_scene_path_candidates(
+            property_scene_paths,
+            include_prim_state=False,
+            stage=before_stage,
+        )
 
     def _record_affected_prim_paths(self) -> None:
         candidates = self._candidates
@@ -1303,10 +1425,10 @@ class ComposedChangeProjection:
         paths.update(key[0] for key in candidates.arcs)
         self._affected_prim_paths = {path for path in paths if path and path != "/"}
 
-    def _before_state(self, prim_path: str) -> _PrimProjectionBaseline:
+    def _before_state(self, prim_path: str) -> _PrimProjectionValues:
         if self._before is None:
             raise RuntimeError("projection before-state has not been captured")
-        return self._before.prims.get(prim_path, _EMPTY_PRIM_BASELINE)
+        return self._before.prims.get(prim_path, _EMPTY_PRIM_VALUES)
 
     def build_events(self) -> list[dict]:
         """Return adapter events representing the post-transaction composition."""
@@ -1326,6 +1448,7 @@ class ComposedChangeProjection:
         projected: list[dict] = []
         for step in _PROJECTION_STEPS:
             projected.extend(getattr(self, step.method_name)())
+        self._projected_events = projected
         return projected
 
     def commit(self) -> None:

--- a/openusdconnect/composed_projection.py
+++ b/openusdconnect/composed_projection.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import cast
@@ -136,24 +136,41 @@ def _is_projectable_prim(prim: Usd.Prim) -> bool:
 
 
 class ComposedProjectionState:
-    """Persistent native-visible state for one mirror stage and adapter.
+    """Last successfully applied native-visible state for one mirror stage.
 
     ``Usd.Notice.ObjectsChanged`` identifies composed consumers only after a
-    layer mutation has occurred. Keeping the last successfully-applied native
-    state makes those post-change paths diffable without accessing the stage's
-    private Pcp cache or scanning every prim for each transaction.
+    layer mutation has occurred. A separately composed shadow stage makes
+    those post-change paths diffable without accessing the private Pcp cache,
+    scanning every prim, or retaining a Python snapshot of the whole stage.
+
+    The snapshot fallback remains available for standalone callers that do
+    not supply ``shadow_stage``. Layered dispatch uses the shadow path.
     """
 
-    def __init__(self, stage: Usd.Stage | None = None):
+    def __init__(
+        self,
+        stage: Usd.Stage | None = None,
+        *,
+        shadow_stage: Usd.Stage | None = None,
+        advance_shadow: Callable[[], None] | None = None,
+    ):
         self._stage: Usd.Stage | None = None
+        self._shadow_stage: Usd.Stage | None = None
+        self._advance_shadow: Callable[[], None] | None = None
         self._baseline: _ProjectionBaseline | None = None
         self._needs_full_reconcile = False
         if stage is not None:
-            self.bind(stage)
+            self.bind(
+                stage,
+                shadow_stage=shadow_stage,
+                advance_shadow=advance_shadow,
+            )
 
     @property
     def baseline(self) -> _ProjectionBaseline:
         if self._baseline is None:
+            if self._shadow_stage is not None:
+                raise RuntimeError("snapshot baseline is unavailable in shadow mode")
             raise RuntimeError("composed projection state is not bound")
         return self._baseline
 
@@ -161,25 +178,58 @@ class ComposedProjectionState:
     def needs_full_reconcile(self) -> bool:
         return self._needs_full_reconcile
 
-    def bind(self, stage: Usd.Stage) -> None:
-        if stage is self._stage and self._baseline is not None:
+    @property
+    def stage(self) -> Usd.Stage | None:
+        return self._stage
+
+    @property
+    def shadow_stage(self) -> Usd.Stage | None:
+        return self._shadow_stage
+
+    def bind(
+        self,
+        stage: Usd.Stage,
+        *,
+        shadow_stage: Usd.Stage | None = None,
+        advance_shadow: Callable[[], None] | None = None,
+    ) -> None:
+        if stage is self._stage and shadow_stage is None and advance_shadow is None:
+            return
+        if shadow_stage is stage:
+            raise ValueError("projection shadow must be a distinct Usd.Stage")
+        if shadow_stage is not None and advance_shadow is None:
+            raise ValueError("shadow projection state requires an advance callback")
+        if (
+            stage is self._stage
+            and shadow_stage is self._shadow_stage
+            and (shadow_stage is not None or self._baseline is not None)
+        ):
+            self._advance_shadow = advance_shadow
             return
         self._stage = stage
-        self._baseline = ComposedChangeProjection._capture_scope(
-            stage,
-            ("/",),
-            recurse=True,
+        self._shadow_stage = shadow_stage
+        self._advance_shadow = advance_shadow
+        self._baseline = (
+            None
+            if shadow_stage is not None
+            else ComposedChangeProjection._capture_scope(
+                stage,
+                ("/",),
+                recurse=True,
+            )
         )
         self._needs_full_reconcile = False
 
     def close(self) -> None:
         self._stage = None
+        self._shadow_stage = None
+        self._advance_shadow = None
         self._baseline = None
         self._needs_full_reconcile = False
 
     def require_full_reconcile(self) -> None:
         """Keep the last adapter baseline but widen the next projection."""
-        if self._baseline is not None:
+        if self._stage is not None:
             self._needs_full_reconcile = True
 
     def commit(self, projection: ComposedChangeProjection) -> None:
@@ -189,6 +239,13 @@ class ComposedProjectionState:
         stage = projection._stage
         if stage is not self._stage:
             raise ValueError("projection stage no longer matches persistent state")
+
+        if self._shadow_stage is not None:
+            if self._advance_shadow is None:
+                raise RuntimeError("shadow projection state cannot advance")
+            self._advance_shadow()
+            self._needs_full_reconcile = False
+            return
 
         subtree_roots = set(projection._resync_prim_roots)
         exact_paths = set(projection._affected_prim_paths)
@@ -568,7 +625,8 @@ class ComposedChangeProjection:
         self._events = events
         self._validate_events(events)
         self._state = state or ComposedProjectionState(stage)
-        self._state.bind(stage)
+        if self._state.stage is not stage:
+            self._state.bind(stage)
         self._reset = reset
         self._resynced_paths: set[Sdf.Path] = set()
         self._changed_info_paths: set[Sdf.Path] = set()
@@ -589,7 +647,9 @@ class ComposedChangeProjection:
             initial_scene_paths,
             extra_arc_candidates,
         )
-        self._before = self._state.baseline
+        self._before = (
+            None if self._state.shadow_stage is not None else self._state.baseline
+        )
         if self._state.needs_full_reconcile:
             self._resynced_paths.add(Sdf.Path.absoluteRootPath)
             self._reapply_all_composed = True
@@ -782,6 +842,17 @@ class ComposedChangeProjection:
         return result
 
     @classmethod
+    def _capture_candidates(
+        cls,
+        stage: Usd.Stage,
+        candidates: _ProjectionCandidates,
+    ) -> _ProjectionBaseline:
+        capture = cls.__new__(cls)
+        capture._stage = stage
+        capture._candidates = candidates
+        return capture._capture_baseline()
+
+    @classmethod
     def _capture_scope(
         cls,
         stage: Usd.Stage,
@@ -798,7 +869,7 @@ class ComposedChangeProjection:
         else:
             for prim_path in prim_paths:
                 capture._add_prim_candidates(stage.GetPrimAtPath(prim_path))
-        return capture._capture_baseline()
+        return cls._capture_candidates(stage, capture._candidates)
 
     def _add_baseline_candidates(
         self,
@@ -817,6 +888,8 @@ class ComposedChangeProjection:
             )
 
         before = self._before
+        if before is None:
+            raise RuntimeError("snapshot baseline is unavailable in shadow mode")
         candidates = self._candidates
         for prim_path, state in before.prims.items():
             if not included(prim_path):
@@ -1007,7 +1080,9 @@ class ComposedChangeProjection:
         paths: Iterable[Sdf.Path],
         *,
         include_prim_state: bool = True,
+        stage: Usd.Stage | None = None,
     ) -> None:
+        source_stage = stage or self._stage
         xform_prims = set()
         seen_prims = set()
         for path in paths:
@@ -1022,18 +1097,24 @@ class ComposedChangeProjection:
                 self._candidates.variants.add(prim_path)
                 self._candidates.active.add(prim_path)
                 self._candidates.instanceable.add(prim_path)
-                prim = self._stage.GetPrimAtPath(prim_path)
+                prim = source_stage.GetPrimAtPath(prim_path)
                 if _is_projectable_prim(prim) and prim.IsA(UsdGeom.PointInstancer):
                     self._candidates.point_instancers[(prim_path, None)].add("inactive_ids")
             if not path.IsPropertyPath():
                 continue
 
-            prop = self._stage.GetPropertyAtPath(path)
-            if self._add_property_candidate(prim_path, str(path.name), prop, prim):
+            prop = source_stage.GetPropertyAtPath(path)
+            if self._add_property_candidate(
+                prim_path,
+                str(path.name),
+                prop,
+                prim,
+                stage=source_stage,
+            ):
                 xform_prims.add(prim_path)
 
         for prim_path in xform_prims:
-            prim = self._stage.GetPrimAtPath(prim_path)
+            prim = source_stage.GetPrimAtPath(prim_path)
             xformable = UsdGeom.Xformable(prim) if _is_projectable_prim(prim) else None
             if not xformable:
                 continue
@@ -1046,8 +1127,11 @@ class ComposedChangeProjection:
         name: str,
         prop: Usd.Property,
         prim: Usd.Prim | None = None,
+        *,
+        stage: Usd.Stage | None = None,
     ) -> bool:
         """Classify one authored property, returning whether it is an xform op."""
+        source_stage = stage or self._stage
         candidates = self._candidates
         if name == "xformOpOrder" or name.startswith("xformOp:"):
             candidates.xforms.add((prim_path, None))
@@ -1065,7 +1149,7 @@ class ComposedChangeProjection:
         elif (purpose := _material_purpose_from_name(name)) is not None:
             candidates.materials.add((prim_path, purpose))
         elif (
-            _is_projectable_prim(prim := prim or self._stage.GetPrimAtPath(prim_path))
+            _is_projectable_prim(prim := prim or source_stage.GetPrimAtPath(prim_path))
             and prim.IsA(UsdGeom.PointInstancer)
             and (field := POINT_INSTANCER_USD_TO_WIRE.get(name))
         ):
@@ -1078,7 +1162,12 @@ class ComposedChangeProjection:
                 candidates.gprim[(prim_path, time)].add(name)
         return False
 
-    def _add_prim_candidates(self, prim: Usd.Prim) -> None:
+    def _add_prim_candidates(
+        self,
+        prim: Usd.Prim,
+        *,
+        stage: Usd.Stage | None = None,
+    ) -> None:
         if not _is_projectable_prim(prim):
             return
         prim_path = str(prim.GetPath())
@@ -1103,6 +1192,7 @@ class ComposedChangeProjection:
                 str(prop.GetName()),
                 prop,
                 prim,
+                stage=stage,
             )
         if has_xform:
             xformable = UsdGeom.Xformable(prim)
@@ -1110,15 +1200,23 @@ class ComposedChangeProjection:
                 (prim_path, time) for time in xformable.GetTimeSamples()
             )
 
-    def _add_subtree_candidates(self, roots: Iterable[str]) -> None:
+    def _add_subtree_candidates(
+        self,
+        roots: Iterable[str],
+        *,
+        stage: Usd.Stage | None = None,
+    ) -> None:
+        source_stage = stage or self._stage
         for root in roots:
             prim = (
-                self._stage.GetPseudoRoot() if str(root) == "/" else self._stage.GetPrimAtPath(root)
+                source_stage.GetPseudoRoot()
+                if str(root) == "/"
+                else source_stage.GetPrimAtPath(root)
             )
             if not prim or not prim.IsValid():
                 continue
             for descendant in Usd.PrimRange.AllPrims(prim):
-                self._add_prim_candidates(descendant)
+                self._add_prim_candidates(descendant, stage=source_stage)
 
     @staticmethod
     def _minimal_roots(paths: Iterable[str]) -> set[str]:
@@ -1163,7 +1261,14 @@ class ComposedChangeProjection:
             if not any(_path_is_at_or_below(path, root) for root in self._resync_prim_roots)
         }
 
-        self._add_baseline_candidates(self._resync_prim_roots, recurse=True)
+        before_stage = self._state.shadow_stage
+        if before_stage is None:
+            self._add_baseline_candidates(self._resync_prim_roots, recurse=True)
+        else:
+            self._add_subtree_candidates(
+                self._resync_prim_roots,
+                stage=before_stage,
+            )
         self._add_subtree_candidates(self._resync_prim_roots)
         prim_scene_paths = {path for path in exact_scene_paths if not path.IsPropertyPath()}
         property_scene_paths = exact_scene_paths - prim_scene_paths
@@ -1172,6 +1277,16 @@ class ComposedChangeProjection:
             property_scene_paths,
             include_prim_state=False,
         )
+        if before_stage is not None:
+            self._add_scene_path_candidates(
+                prim_scene_paths,
+                stage=before_stage,
+            )
+            self._add_scene_path_candidates(
+                property_scene_paths,
+                include_prim_state=False,
+                stage=before_stage,
+            )
 
     def _record_affected_prim_paths(self) -> None:
         candidates = self._candidates
@@ -1189,6 +1304,8 @@ class ComposedChangeProjection:
         self._affected_prim_paths = {path for path in paths if path and path != "/"}
 
     def _before_state(self, prim_path: str) -> _PrimProjectionBaseline:
+        if self._before is None:
+            raise RuntimeError("projection before-state has not been captured")
         return self._before.prims.get(prim_path, _EMPTY_PRIM_BASELINE)
 
     def build_events(self) -> list[dict]:
@@ -1200,6 +1317,11 @@ class ComposedChangeProjection:
         if self._subtree_roots:
             self._add_subtree_candidates(self._subtree_roots)
         self._record_affected_prim_paths()
+        if (before_stage := self._state.shadow_stage) is not None:
+            self._before = self._capture_candidates(
+                before_stage,
+                self._candidates,
+            )
 
         projected: list[dict] = []
         for step in _PROJECTION_STEPS:

--- a/openusdconnect/composed_projection.py
+++ b/openusdconnect/composed_projection.py
@@ -136,29 +136,28 @@ def _is_projectable_prim(prim: Usd.Prim) -> bool:
     return bool(prim.GetTypeName() or prim.GetAuthoredProperties() or not tuple(prim.GetChildren()))
 
 
-class _OwnedStageShadow:
-    """Independent shadow for callers without an externally managed stage.
+class _OwnedAdapterStateStage:
+    """Internally managed stage containing the last adapter-visible state.
 
     All-anonymous root/session sublayer trees are cloned exactly with
-    ``TransferContent`` and identifier rewiring. File-backed local layers use
-    ``UsdUtils.FlattenLayerStack`` so relative asset paths retain their source
-    anchors while references, payloads, inherits, specializes, and variants
-    remain composition arcs.
+    ``TransferContent`` and identifier rewiring. Resolver-backed local layers
+    are consolidated with ``UsdUtils.FlattenLayerStack`` so asset paths retain
+    their source anchors while composition arcs remain intact.
     """
 
     def __init__(self, live_stage: Usd.Stage):
         self._live_stage = live_stage
-        self._stage: Usd.Stage | None = None
-        self._sources: dict[str, Sdf.Layer] = {}
-        self._clones: dict[str, Sdf.Layer] = {}
-        self._flattened = False
-        self._rebuild()
+        self._previous_stage: Usd.Stage | None = None
+        self._source_layers: dict[str, Sdf.Layer] = {}
+        self._cloned_layers: dict[str, Sdf.Layer] = {}
+        self._uses_consolidated_layer = False
+        self._rebuild_previous_stage()
 
     @property
-    def stage(self) -> Usd.Stage:
-        if self._stage is None:
-            raise RuntimeError("owned projection shadow is closed")
-        return self._stage
+    def previous_stage(self) -> Usd.Stage:
+        if self._previous_stage is None:
+            raise RuntimeError("owned adapter-state stage is closed")
+        return self._previous_stage
 
     @staticmethod
     def _resolve_sublayer(layer: Sdf.Layer, path: str) -> Sdf.Layer | None:
@@ -187,7 +186,7 @@ class _OwnedStageShadow:
     @staticmethod
     def _clone_layer(source: Sdf.Layer) -> Sdf.Layer:
         extension = source.GetFileFormat().primaryFileExtension or "usda"
-        clone = Sdf.Layer.CreateAnonymous(f"projection-shadow.{extension}")
+        clone = Sdf.Layer.CreateAnonymous(f"previous-adapter-state.{extension}")
         clone.TransferContent(source)
         return clone
 
@@ -208,169 +207,173 @@ class _OwnedStageShadow:
         return str(resolved) if resolved else anchored
 
     def _rewire_sublayers(self) -> None:
-        for identifier, source in self._sources.items():
-            clone = self._clones[identifier]
+        for identifier, source in self._source_layers.items():
+            clone = self._cloned_layers[identifier]
             for index, path in enumerate(tuple(source.subLayerPaths)):
                 child = self._resolve_sublayer(source, path)
                 if child is None:
                     continue
-                child_clone = self._clones.get(child.identifier)
+                child_clone = self._cloned_layers.get(child.identifier)
                 if child_clone is not None:
                     clone.subLayerPaths[index] = child_clone.identifier
 
     def _mapped_muted_layers(self) -> set[str]:
         return {
-            self._clones[identifier].identifier
-            if identifier in self._clones
+            self._cloned_layers[identifier].identifier
+            if identifier in self._cloned_layers
             else identifier
             for identifier in self._live_stage.GetMutedLayers()
         }
 
-    def _sync_runtime_state(self) -> None:
-        shadow = self.stage
+    def _sync_stage_controls(self) -> None:
+        previous = self.previous_stage
         live = self._live_stage
         population_mask = live.GetPopulationMask()
-        if shadow.GetPopulationMask() != population_mask:
-            shadow.SetPopulationMask(population_mask)
+        if previous.GetPopulationMask() != population_mask:
+            previous.SetPopulationMask(population_mask)
 
         load_rules = live.GetLoadRules()
-        if shadow.GetLoadRules() != load_rules:
-            shadow.SetLoadRules(load_rules)
-        if self._flattened:
+        if previous.GetLoadRules() != load_rules:
+            previous.SetLoadRules(load_rules)
+        if self._uses_consolidated_layer:
             return
 
         desired_muted = self._mapped_muted_layers()
-        current_muted = set(shadow.GetMutedLayers())
+        current_muted = set(previous.GetMutedLayers())
         to_mute = sorted(desired_muted - current_muted)
         to_unmute = sorted(current_muted - desired_muted)
         if to_mute or to_unmute:
-            shadow.MuteAndUnmuteLayers(to_mute, to_unmute)
+            previous.MuteAndUnmuteLayers(to_mute, to_unmute)
 
-    def prepare(self) -> None:
-        """Follow runtime mask/load changes without advancing authored state."""
-        self._sync_runtime_state()
+    def sync_stage_controls(self) -> None:
+        """Follow mask/load changes without advancing adapter-visible values."""
+        self._sync_stage_controls()
 
-    def advance(self, projected_events: list[dict] | None) -> None:
-        """Advance native-visible state after adapter success.
+    def advance_after_delivery(self, delivered_events: list[dict] | None) -> None:
+        """Record the state successfully delivered to the native adapter.
 
-        File-backed shadows are already a consolidated local layer stack, so
-        the projected adapter batch is their cheapest exact advancement. A
-        caller that commits without building events falls back to rebuilding.
+        A consolidated previous stage advances by replaying the delivered
+        semantic adapter batch. ``None`` means no batch was built, so the safe
+        fallback is to reconstruct the previous stage from the live stage.
         """
-        if self._flattened:
-            if projected_events is None:
-                self._rebuild()
+        if self._uses_consolidated_layer:
+            if delivered_events is None:
+                self._rebuild_previous_stage()
                 return
             from .adapters import UsdStageAdapter
 
-            shadow = self.stage
-            if not projected_events:
-                self._sync_runtime_state()
+            previous = self.previous_stage
+            if not delivered_events:
+                self._sync_stage_controls()
                 return
             try:
-                with Usd.EditContext(shadow, shadow.GetRootLayer()):
-                    UsdStageAdapter(shadow).apply_events(projected_events)
-                self._sync_runtime_state()
+                with Usd.EditContext(previous, previous.GetRootLayer()):
+                    UsdStageAdapter(previous).apply_events(delivered_events)
+                self._sync_stage_controls()
             except Exception:
-                self._rebuild()
+                self._rebuild_previous_stage()
             return
 
-        current_sources = self._collect_local_layers(self._live_stage)
-        if set(current_sources) != set(self._sources):
-            self._rebuild(current_sources)
+        current_source_layers = self._collect_local_layers(self._live_stage)
+        if set(current_source_layers) != set(self._source_layers):
+            self._rebuild_previous_stage(current_source_layers)
             return
 
-        self._sources = current_sources
+        self._source_layers = current_source_layers
         with Sdf.ChangeBlock():
-            for identifier, source in self._sources.items():
-                self._clones[identifier].TransferContent(source)
+            for identifier, source in self._source_layers.items():
+                self._cloned_layers[identifier].TransferContent(source)
             self._rewire_sublayers()
-        self._sync_runtime_state()
+        self._sync_stage_controls()
 
-    def _rebuild(self, sources: dict[str, Sdf.Layer] | None = None) -> None:
+    def _rebuild_previous_stage(
+        self,
+        source_layers: dict[str, Sdf.Layer] | None = None,
+    ) -> None:
         live = self._live_stage
-        self._stage = None
-        self._sources = sources or self._collect_local_layers(live)
-        self._flattened = any(not layer.anonymous for layer in self._sources.values())
-        if self._flattened:
+        self._previous_stage = None
+        self._source_layers = source_layers or self._collect_local_layers(live)
+        self._uses_consolidated_layer = any(
+            not layer.anonymous for layer in self._source_layers.values()
+        )
+        if self._uses_consolidated_layer:
             root = UsdUtils.FlattenLayerStack(
                 live,
                 resolveAssetPathFn=self._freeze_asset_path,
             )
-            session = Sdf.Layer.CreateAnonymous("projection-shadow-session.usda")
-            shadow = Usd.Stage.OpenMasked(
+            session = Sdf.Layer.CreateAnonymous("previous-adapter-state-session.usda")
+            previous = Usd.Stage.OpenMasked(
                 root,
                 session,
                 live.GetPathResolverContext(),
                 live.GetPopulationMask(),
                 Usd.Stage.LoadNone,
             )
-            if shadow is None:
-                raise RuntimeError("could not open flattened local-stack projection shadow")
-            self._clones = {}
-            self._stage = shadow
-            self._sync_runtime_state()
+            if previous is None:
+                raise RuntimeError("could not open consolidated adapter-state stage")
+            self._cloned_layers = {}
+            self._previous_stage = previous
+            self._sync_stage_controls()
             return
 
-        self._clones = {
+        self._cloned_layers = {
             identifier: self._clone_layer(source)
-            for identifier, source in self._sources.items()
+            for identifier, source in self._source_layers.items()
         }
         self._rewire_sublayers()
-        root = self._clones[live.GetRootLayer().identifier]
-        session = self._clones[live.GetSessionLayer().identifier]
-        shadow = Usd.Stage.OpenMasked(
+        root = self._cloned_layers[live.GetRootLayer().identifier]
+        session = self._cloned_layers[live.GetSessionLayer().identifier]
+        previous = Usd.Stage.OpenMasked(
             root,
             session,
             live.GetPathResolverContext(),
             live.GetPopulationMask(),
             Usd.Stage.LoadNone,
         )
-        if shadow is None:
-            raise RuntimeError("could not open owned projection shadow stage")
-        self._stage = shadow
-        self._sync_runtime_state()
+        if previous is None:
+            raise RuntimeError("could not open cloned adapter-state stage")
+        self._previous_stage = previous
+        self._sync_stage_controls()
 
     def close(self) -> None:
-        self._stage = None
-        self._sources.clear()
-        self._clones.clear()
-        self._flattened = False
+        self._previous_stage = None
+        self._source_layers.clear()
+        self._cloned_layers.clear()
+        self._uses_consolidated_layer = False
 
 
 class ComposedProjectionState:
-    """Last successfully applied native-visible state for one mirror stage.
+    """Previous adapter-visible state for one live composed stage.
 
     ``Usd.Notice.ObjectsChanged`` identifies composed consumers only after a
-    layer mutation has occurred. A separately composed shadow stage makes
-    those post-change paths diffable without accessing the private Pcp cache,
-    scanning every prim, or retaining a Python snapshot of the whole stage.
+    layer mutation has occurred. A separate previous stage makes those
+    post-change paths diffable without accessing the private Pcp cache,
+    scanning every prim, or retaining a Python value snapshot of the stage.
 
-    Layered dispatch supplies its incrementally-replayed shadow. Standalone
-    callers receive an owned shadow with independent clones of the editable
-    root/session sublayer trees. File-backed local stacks use OpenUSD's native
-    layer-stack flattening so relative asset paths remain correctly anchored.
+    Layered dispatch may supply an externally managed previous stage.
+    Standalone callers receive an internally managed one. Resolver-backed
+    layer stacks are consolidated natively so asset paths remain anchored.
     """
 
     def __init__(
         self,
         stage: Usd.Stage | None = None,
         *,
-        shadow_stage: Usd.Stage | None = None,
-        advance_shadow: Callable[[], None] | None = None,
+        previous_stage: Usd.Stage | None = None,
+        advance_previous_stage: Callable[[], None] | None = None,
     ):
-        self._stage: Usd.Stage | None = None
-        self._shadow_stage: Usd.Stage | None = None
-        self._advance_shadow: Callable[[], None] | None = None
-        self._owned_shadow: _OwnedStageShadow | None = None
+        self._live_stage: Usd.Stage | None = None
+        self._external_previous_stage: Usd.Stage | None = None
+        self._advance_external_previous_stage: Callable[[], None] | None = None
+        self._owned_previous_stage: _OwnedAdapterStateStage | None = None
         self._resolver_notice_key = None
         self._resolver_notice_callback = None
         self._needs_full_reconcile = False
         if stage is not None:
             self.bind(
                 stage,
-                shadow_stage=shadow_stage,
-                advance_shadow=advance_shadow,
+                previous_stage=previous_stage,
+                advance_previous_stage=advance_previous_stage,
             )
 
     @property
@@ -378,17 +381,19 @@ class ComposedProjectionState:
         return self._needs_full_reconcile
 
     @property
-    def stage(self) -> Usd.Stage | None:
-        return self._stage
+    def live_stage(self) -> Usd.Stage | None:
+        """Current composed stage whose changes are being projected."""
+        return self._live_stage
 
     @property
-    def shadow_stage(self) -> Usd.Stage | None:
-        if self._owned_shadow is not None:
-            return self._owned_shadow.stage
-        return self._shadow_stage
+    def previous_stage(self) -> Usd.Stage | None:
+        """Stage representing the last state delivered to the adapter."""
+        if self._owned_previous_stage is not None:
+            return self._owned_previous_stage.previous_stage
+        return self._external_previous_stage
 
     def _on_resolver_changed(self, notice, _sender) -> None:
-        stage = self._stage
+        stage = self._live_stage
         if stage is not None and notice.AffectsContext(stage.GetPathResolverContext()):
             self.require_full_reconcile()
 
@@ -408,49 +413,53 @@ class ComposedProjectionState:
             )
 
     def prepare(self, stage: Usd.Stage) -> None:
-        if self._stage is not stage:
+        if self._live_stage is not stage:
             self.bind(stage)
-        elif self._owned_shadow is not None:
-            self._owned_shadow.prepare()
+        elif self._owned_previous_stage is not None:
+            self._owned_previous_stage.sync_stage_controls()
 
     def bind(
         self,
         stage: Usd.Stage,
         *,
-        shadow_stage: Usd.Stage | None = None,
-        advance_shadow: Callable[[], None] | None = None,
+        previous_stage: Usd.Stage | None = None,
+        advance_previous_stage: Callable[[], None] | None = None,
     ) -> None:
         self._ensure_resolver_listener()
-        if stage is self._stage and shadow_stage is None and advance_shadow is None:
-            return
-        if shadow_stage is stage:
-            raise ValueError("projection shadow must be a distinct Usd.Stage")
-        if shadow_stage is not None and advance_shadow is None:
-            raise ValueError("shadow projection state requires an advance callback")
         if (
-            stage is self._stage
-            and shadow_stage is self._shadow_stage
-            and shadow_stage is not None
+            stage is self._live_stage
+            and previous_stage is None
+            and advance_previous_stage is None
         ):
-            self._advance_shadow = advance_shadow
             return
-        if self._owned_shadow is not None:
-            self._owned_shadow.close()
-        self._stage = stage
-        self._shadow_stage = shadow_stage
-        self._advance_shadow = advance_shadow
-        self._owned_shadow = (
-            _OwnedStageShadow(stage) if shadow_stage is None else None
+        if previous_stage is stage:
+            raise ValueError("previous adapter-state stage must be distinct")
+        if previous_stage is not None and advance_previous_stage is None:
+            raise ValueError("external previous stage requires an advance callback")
+        if (
+            stage is self._live_stage
+            and previous_stage is self._external_previous_stage
+            and previous_stage is not None
+        ):
+            self._advance_external_previous_stage = advance_previous_stage
+            return
+        if self._owned_previous_stage is not None:
+            self._owned_previous_stage.close()
+        self._live_stage = stage
+        self._external_previous_stage = previous_stage
+        self._advance_external_previous_stage = advance_previous_stage
+        self._owned_previous_stage = (
+            _OwnedAdapterStateStage(stage) if previous_stage is None else None
         )
         self._needs_full_reconcile = False
 
     def close(self) -> None:
-        if self._owned_shadow is not None:
-            self._owned_shadow.close()
-        self._stage = None
-        self._shadow_stage = None
-        self._advance_shadow = None
-        self._owned_shadow = None
+        if self._owned_previous_stage is not None:
+            self._owned_previous_stage.close()
+        self._live_stage = None
+        self._external_previous_stage = None
+        self._advance_external_previous_stage = None
+        self._owned_previous_stage = None
         self._needs_full_reconcile = False
         if self._resolver_notice_key is not None:
             self._resolver_notice_key.Revoke()
@@ -458,26 +467,28 @@ class ComposedProjectionState:
             self._resolver_notice_callback = None
 
     def require_full_reconcile(self) -> None:
-        """Keep the last adapter baseline but widen the next projection."""
-        if self._stage is not None:
+        """Keep the previous stage but compare the entire live stage next."""
+        if self._live_stage is not None:
             self._needs_full_reconcile = True
 
     def commit(self, projection: ComposedChangeProjection) -> None:
-        """Advance the baseline after the native adapter applied successfully."""
+        """Advance the previous stage after native adapter delivery succeeds."""
         if projection._state is not self:
             raise ValueError("projection belongs to a different persistent state")
         stage = projection._stage
-        if stage is not self._stage:
+        if stage is not self._live_stage:
             raise ValueError("projection stage no longer matches persistent state")
 
-        if self._owned_shadow is not None:
-            self._owned_shadow.advance(projection._projected_events)
-        elif self._shadow_stage is not None:
-            if self._advance_shadow is None:
-                raise RuntimeError("shadow projection state cannot advance")
-            self._advance_shadow()
+        if self._owned_previous_stage is not None:
+            self._owned_previous_stage.advance_after_delivery(
+                projection._built_adapter_events,
+            )
+        elif self._external_previous_stage is not None:
+            if self._advance_external_previous_stage is None:
+                raise RuntimeError("external previous stage cannot advance")
+            self._advance_external_previous_stage()
         else:
-            raise RuntimeError("composed projection state has no shadow")
+            raise RuntimeError("composed projection state has no previous stage")
         self._needs_full_reconcile = False
 
 
@@ -821,7 +832,7 @@ class ComposedChangeProjection:
         self._asset_resync_paths: set[Sdf.Path] = set()
         self._resync_prim_roots: set[str] = set()
         self._affected_prim_paths: set[str] = set()
-        self._projected_events: list[dict] | None = None
+        self._built_adapter_events: list[dict] | None = None
         self._notice_key = None
         self._prepare_reapplication_scope(
             reapply_all_composed=reapply_all_composed,
@@ -836,7 +847,7 @@ class ComposedChangeProjection:
             initial_scene_paths,
             extra_arc_candidates,
         )
-        self._before: _ProjectionValues | None = None
+        self._previous_values: _ProjectionValues | None = None
         if self._state.needs_full_reconcile:
             self._resynced_paths.add(Sdf.Path.absoluteRootPath)
             self._reapply_all_composed = True
@@ -1385,12 +1396,12 @@ class ComposedChangeProjection:
             if not any(_path_is_at_or_below(path, root) for root in self._resync_prim_roots)
         }
 
-        before_stage = self._state.shadow_stage
-        if before_stage is None:
-            raise RuntimeError("composed projection state has no shadow stage")
+        previous_stage = self._state.previous_stage
+        if previous_stage is None:
+            raise RuntimeError("composed projection state has no previous stage")
         self._add_subtree_candidates(
             self._resync_prim_roots,
-            stage=before_stage,
+            stage=previous_stage,
         )
         self._add_subtree_candidates(self._resync_prim_roots)
         prim_scene_paths = {path for path in exact_scene_paths if not path.IsPropertyPath()}
@@ -1402,12 +1413,12 @@ class ComposedChangeProjection:
         )
         self._add_scene_path_candidates(
             prim_scene_paths,
-            stage=before_stage,
+            stage=previous_stage,
         )
         self._add_scene_path_candidates(
             property_scene_paths,
             include_prim_state=False,
-            stage=before_stage,
+            stage=previous_stage,
         )
 
     def _record_affected_prim_paths(self) -> None:
@@ -1425,10 +1436,10 @@ class ComposedChangeProjection:
         paths.update(key[0] for key in candidates.arcs)
         self._affected_prim_paths = {path for path in paths if path and path != "/"}
 
-    def _before_state(self, prim_path: str) -> _PrimProjectionValues:
-        if self._before is None:
-            raise RuntimeError("projection before-state has not been captured")
-        return self._before.prims.get(prim_path, _EMPTY_PRIM_VALUES)
+    def _previous_prim_values(self, prim_path: str) -> _PrimProjectionValues:
+        if self._previous_values is None:
+            raise RuntimeError("previous adapter values have not been captured")
+        return self._previous_values.prims.get(prim_path, _EMPTY_PRIM_VALUES)
 
     def build_events(self) -> list[dict]:
         """Return adapter events representing the post-transaction composition."""
@@ -1439,20 +1450,20 @@ class ComposedChangeProjection:
         if self._subtree_roots:
             self._add_subtree_candidates(self._subtree_roots)
         self._record_affected_prim_paths()
-        if (before_stage := self._state.shadow_stage) is not None:
-            self._before = self._capture_candidates(
-                before_stage,
+        if (previous_stage := self._state.previous_stage) is not None:
+            self._previous_values = self._capture_candidates(
+                previous_stage,
                 self._candidates,
             )
 
-        projected: list[dict] = []
+        adapter_events: list[dict] = []
         for step in _PROJECTION_STEPS:
-            projected.extend(getattr(self, step.method_name)())
-        self._projected_events = projected
-        return projected
+            adapter_events.extend(getattr(self, step.method_name)())
+        self._built_adapter_events = adapter_events
+        return adapter_events
 
     def commit(self) -> None:
-        """Record that the projected events reached the native adapter."""
+        """Record that the built adapter events were delivered successfully."""
         self.close()
         self._state.commit(self)
 
@@ -1491,7 +1502,7 @@ class ComposedChangeProjection:
         after = self._read_arcs(self._candidates.arcs)
         result = []
         for (prim_path, kind), entries in after.items():
-            before = (self._before_state(prim_path).arcs or {}).get(kind, [])
+            before = (self._previous_prim_values(prim_path).arcs or {}).get(kind, [])
             reapply_composed = self._should_reapply_composed(prim_path)
             if entries == before and not reapply_composed:
                 continue
@@ -1529,8 +1540,8 @@ class ComposedChangeProjection:
             old_after = _is_projectable_prim(self._stage.GetPrimAtPath(old_path))
             new_after = _is_projectable_prim(self._stage.GetPrimAtPath(new_path))
             if (
-                self._before_state(old_path).valid
-                and not self._before_state(new_path).valid
+                self._previous_prim_values(old_path).valid
+                and not self._previous_prim_values(new_path).valid
                 and not old_after
                 and new_after
             ):
@@ -1553,7 +1564,7 @@ class ComposedChangeProjection:
                 continue
             prim = self._stage.GetPrimAtPath(prim_path)
             valid_after = _is_projectable_prim(prim)
-            before_state = self._before_state(prim_path)
+            before_state = self._previous_prim_values(prim_path)
             valid_before = before_state.valid
             before_type = before_state.type_state
             after_type = types_after.get(prim_path)
@@ -1598,7 +1609,7 @@ class ComposedChangeProjection:
             prim = self._stage.GetPrimAtPath(prim_path)
             if not _is_projectable_prim(prim):
                 continue
-            before = (self._before_state(prim_path).gprim or {}).get(time, {})
+            before = (self._previous_prim_values(prim_path).gprim or {}).get(time, {})
             selected = {
                 name: value
                 for name, value in values.items()
@@ -1668,7 +1679,10 @@ class ComposedChangeProjection:
             prim = self._stage.GetPrimAtPath(key[0])
             if not _is_projectable_prim(prim) or not prim.IsA(UsdGeom.PointInstancer):
                 continue
-            before = (self._before_state(key[0]).point_instancers or {}).get(key[1], {})
+            before = (self._previous_prim_values(key[0]).point_instancers or {}).get(
+                key[1],
+                {},
+            )
             fields = sorted(
                 field
                 for field in self._candidates.point_instancers[key]
@@ -1705,7 +1719,7 @@ class ComposedChangeProjection:
         for prim_path, selections in after.items():
             if not _is_projectable_prim(self._stage.GetPrimAtPath(prim_path)):
                 continue
-            before = self._before_state(prim_path).variants or {}
+            before = self._previous_prim_values(prim_path).variants or {}
             if not self._should_reapply_composed(prim_path) and selections == before:
                 continue
             projected = dict(selections)
@@ -1741,7 +1755,7 @@ class ComposedChangeProjection:
                 continue
             if (
                 not self._should_reapply_composed(key[0])
-                and (self._before_state(key[0]).materials or {}).get(key[1], "")
+                and (self._previous_prim_values(key[0]).materials or {}).get(key[1], "")
                 == material_path
             ):
                 continue
@@ -1862,7 +1876,10 @@ class ComposedChangeProjection:
         for key, state in after.items():
             if not _is_projectable_prim(self._stage.GetPrimAtPath(key[0])):
                 continue
-            before = (self._before_state(key[0]).connectables or {}).get(key[1], {})
+            before = (self._previous_prim_values(key[0]).connectables or {}).get(
+                key[1],
+                {},
+            )
             previous_inputs = before.get("inputs", {})
             changed_inputs = {
                 name: value
@@ -1923,10 +1940,13 @@ class ComposedChangeProjection:
             }
             for prim_path, active in after.items()
             if active is not None
-            and (active is False or self._before_state(prim_path).active is not None)
+            and (
+                active is False
+                or self._previous_prim_values(prim_path).active is not None
+            )
             and (
                 self._should_reapply_composed(prim_path)
-                or self._before_state(prim_path).active != active
+                or self._previous_prim_values(prim_path).active != active
             )
         ]
 
@@ -1951,7 +1971,8 @@ class ComposedChangeProjection:
         for key, visible in after.items():
             if visible is None or (
                 not self._should_reapply_composed(key[0])
-                and (self._before_state(key[0]).visibility or {}).get(key[1]) == visible
+                and (self._previous_prim_values(key[0]).visibility or {}).get(key[1])
+                == visible
             ):
                 continue
             event = {
@@ -1983,11 +2004,11 @@ class ComposedChangeProjection:
             if instanceable is not None
             and (
                 instanceable is True
-                or self._before_state(prim_path).instanceable is not None
+                or self._previous_prim_values(prim_path).instanceable is not None
             )
             and (
                 self._should_reapply_composed(prim_path)
-                or self._before_state(prim_path).instanceable != instanceable
+                or self._previous_prim_values(prim_path).instanceable != instanceable
             )
         ]
 
@@ -2011,7 +2032,9 @@ class ComposedChangeProjection:
             xformable = UsdGeom.Xformable(prim)
             if not xformable:
                 continue
-            changed = (self._before_state(prim_path).xforms or {}).get(time) != after.get(key)
+            changed = (self._previous_prim_values(prim_path).xforms or {}).get(
+                time,
+            ) != after.get(key)
             reapply_composed = self._should_reapply_composed(prim_path)
             if not (reapply_composed or changed or prim_path in ensure_ops):
                 continue

--- a/openusdconnect/composed_projection.py
+++ b/openusdconnect/composed_projection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -56,6 +57,21 @@ _TRAILING_DIRECT_KINDS = NATIVE_DIRECT_KINDS - _COMPOSITION_DIRECT_KINDS
 
 
 _PrimTime = tuple[str, float | None]
+LOG = logging.getLogger(__name__)
+
+
+class NativeSceneRebuildRequired(RuntimeError):
+    """Incremental delivery is paused until native state is reconstructed."""
+
+
+_NATIVE_REBUILD_MESSAGE = (
+    "the stage's resolver context changed while using shared-root native projection; "
+    "incremental delivery is paused because prior composed topology is no longer "
+    "available. Recreate the receiver/dispatcher and native scene, rebind a "
+    "replacement stage and reconstruct native state, restart the integration, "
+    "or rebuild the native scene and call "
+    "EventDispatcher.acknowledge_native_scene_rebuilt()."
+)
 
 
 @dataclass
@@ -353,6 +369,11 @@ class ComposedProjectionState:
     Layered dispatch may supply an externally managed previous stage.
     Standalone callers receive an internally managed one. Resolver-backed
     layer stacks are consolidated natively so asset paths remain anchored.
+
+    Resolver refresh has two deliberately different recovery states. An owned,
+    resolver-isolated previous stage retains the old composition and requests a
+    full reconcile. A shared-root external previous stage loses that history,
+    so incremental delivery stops until the native scene is rebuilt.
     """
 
     def __init__(
@@ -361,6 +382,7 @@ class ComposedProjectionState:
         *,
         previous_stage: Usd.Stage | None = None,
         advance_previous_stage: Callable[[], None] | None = None,
+        resolver_refresh_requires_native_rebuild: bool = False,
     ):
         self._live_stage: Usd.Stage | None = None
         self._external_previous_stage: Usd.Stage | None = None
@@ -369,16 +391,31 @@ class ComposedProjectionState:
         self._resolver_notice_key = None
         self._resolver_notice_callback = None
         self._needs_full_reconcile = False
+        self._resolver_refresh_requires_native_rebuild = False
+        self._native_scene_rebuild_required = False
         if stage is not None:
             self.bind(
                 stage,
                 previous_stage=previous_stage,
                 advance_previous_stage=advance_previous_stage,
+                resolver_refresh_requires_native_rebuild=(
+                    resolver_refresh_requires_native_rebuild
+                ),
             )
 
     @property
     def needs_full_reconcile(self) -> bool:
         return self._needs_full_reconcile
+
+    @property
+    def native_scene_rebuild_required(self) -> bool:
+        """Whether native delivery is paused until the scene is reconstructed."""
+        return self._native_scene_rebuild_required
+
+    def ensure_native_projection_safe(self) -> None:
+        """Raise before consuming input when incremental projection is unsafe."""
+        if self._native_scene_rebuild_required:
+            raise NativeSceneRebuildRequired(_NATIVE_REBUILD_MESSAGE)
 
     @property
     def live_stage(self) -> Usd.Stage | None:
@@ -395,7 +432,12 @@ class ComposedProjectionState:
     def _on_resolver_changed(self, notice, _sender) -> None:
         stage = self._live_stage
         if stage is not None and notice.AffectsContext(stage.GetPathResolverContext()):
-            self.require_full_reconcile()
+            if self._resolver_refresh_requires_native_rebuild:
+                if not self._native_scene_rebuild_required:
+                    LOG.error(_NATIVE_REBUILD_MESSAGE)
+                self._native_scene_rebuild_required = True
+            else:
+                self.require_full_reconcile()
 
     def _ensure_resolver_listener(self) -> None:
         if self._resolver_notice_key is None:
@@ -415,7 +457,9 @@ class ComposedProjectionState:
     def prepare(self, stage: Usd.Stage) -> None:
         if self._live_stage is not stage:
             self.bind(stage)
-        elif self._owned_previous_stage is not None:
+        else:
+            self.ensure_native_projection_safe()
+        if self._owned_previous_stage is not None:
             self._owned_previous_stage.sync_stage_controls()
 
     def bind(
@@ -424,6 +468,7 @@ class ComposedProjectionState:
         *,
         previous_stage: Usd.Stage | None = None,
         advance_previous_stage: Callable[[], None] | None = None,
+        resolver_refresh_requires_native_rebuild: bool = False,
     ) -> None:
         self._ensure_resolver_listener()
         if (
@@ -442,6 +487,9 @@ class ComposedProjectionState:
             and previous_stage is not None
         ):
             self._advance_external_previous_stage = advance_previous_stage
+            self._resolver_refresh_requires_native_rebuild = (
+                resolver_refresh_requires_native_rebuild
+            )
             return
         if self._owned_previous_stage is not None:
             self._owned_previous_stage.close()
@@ -452,6 +500,24 @@ class ComposedProjectionState:
             _OwnedAdapterStateStage(stage) if previous_stage is None else None
         )
         self._needs_full_reconcile = False
+        self._resolver_refresh_requires_native_rebuild = (
+            resolver_refresh_requires_native_rebuild
+        )
+        self._native_scene_rebuild_required = False
+
+    def acknowledge_native_scene_rebuilt(self) -> None:
+        """Advance the baseline and resume after native state reconstruction."""
+        if self._live_stage is None:
+            raise RuntimeError("composed projection state is not bound")
+        if not self._native_scene_rebuild_required:
+            return
+        if self._external_previous_stage is None:
+            raise RuntimeError("native rebuild guard requires an external previous stage")
+        if self._advance_external_previous_stage is None:
+            raise RuntimeError("external previous stage cannot advance")
+        self._advance_external_previous_stage()
+        self._native_scene_rebuild_required = False
+        self._needs_full_reconcile = False
 
     def close(self) -> None:
         if self._owned_previous_stage is not None:
@@ -461,6 +527,8 @@ class ComposedProjectionState:
         self._advance_external_previous_stage = None
         self._owned_previous_stage = None
         self._needs_full_reconcile = False
+        self._resolver_refresh_requires_native_rebuild = False
+        self._native_scene_rebuild_required = False
         if self._resolver_notice_key is not None:
             self._resolver_notice_key.Revoke()
             self._resolver_notice_key = None

--- a/openusdconnect/dispatcher.py
+++ b/openusdconnect/dispatcher.py
@@ -181,32 +181,32 @@ class _SharedStageBinding:
             self._events[new_key] = event
 
 
-class _LayeredProjectionShadow:
-    """Independent last-successful stage for native composed projection."""
+class _LayeredPreviousStage:
+    """Last layered USD state successfully delivered to a native adapter."""
 
     def __init__(self):
         self._live_stage: Usd.Stage | None = None
         self._live_router: LayerKeyRouter | None = None
-        self._stage: Usd.Stage | None = None
-        self._router: LayerKeyRouter | None = None
-        self._incremental_prepared = False
-        self._pending_incremental = None
+        self._previous_stage: Usd.Stage | None = None
+        self._previous_router: LayerKeyRouter | None = None
+        self._delivery_prepared = False
+        self._pending_delivery = None
 
     @property
-    def stage(self) -> Usd.Stage:
-        if self._stage is None:
-            raise RuntimeError("projection shadow is not bound")
-        return self._stage
+    def previous_stage(self) -> Usd.Stage:
+        if self._previous_stage is None:
+            raise RuntimeError("layered previous stage is not bound")
+        return self._previous_stage
 
     def bind(self, live_stage: Usd.Stage, live_router: LayerKeyRouter) -> None:
         if live_stage is self._live_stage and live_router is self._live_router:
-            shadow_stage = self.stage
+            previous_stage = self.previous_stage
             population_mask = live_stage.GetPopulationMask()
-            if shadow_stage.GetPopulationMask() != population_mask:
-                shadow_stage.SetPopulationMask(population_mask)
+            if previous_stage.GetPopulationMask() != population_mask:
+                previous_stage.SetPopulationMask(population_mask)
             load_rules = live_stage.GetLoadRules()
-            if shadow_stage.GetLoadRules() != load_rules:
-                shadow_stage.SetLoadRules(load_rules)
+            if previous_stage.GetLoadRules() != load_rules:
+                previous_stage.SetLoadRules(load_rules)
             return
         from pxr import Sdf, Usd
 
@@ -217,32 +217,32 @@ class _LayeredProjectionShadow:
         if not isinstance(live_router, LogicalLayerRouter):
             raise TypeError("layered native projection requires a LogicalLayerRouter")
 
-        shadow_session = Sdf.Layer.CreateAnonymous("native-projection-shadow-session.usda")
-        shadow_session.TransferContent(live_stage.GetSessionLayer())
+        previous_session = Sdf.Layer.CreateAnonymous("previous-adapter-state-session.usda")
+        previous_session.TransferContent(live_stage.GetSessionLayer())
         replace_managed_sublayers(
-            shadow_session,
+            previous_session,
             [],
             live_router.layer_identifiers,
         )
-        shadow_stage = Usd.Stage.OpenMasked(
+        previous_stage = Usd.Stage.OpenMasked(
             live_stage.GetRootLayer(),
-            shadow_session,
+            previous_session,
             live_stage.GetPathResolverContext(),
             live_stage.GetPopulationMask(),
             Usd.Stage.LoadNone,
         )
-        if shadow_stage is None:
-            raise RuntimeError("could not open native projection shadow stage")
-        shadow_router = LogicalLayerRouter(shadow_stage)
-        shadow_router.synchronize_from(live_router)
-        shadow_stage.SetLoadRules(live_stage.GetLoadRules())
+        if previous_stage is None:
+            raise RuntimeError("could not open layered previous stage")
+        previous_router = LogicalLayerRouter(previous_stage)
+        previous_router.synchronize_from(live_router)
+        previous_stage.SetLoadRules(live_stage.GetLoadRules())
 
         self._live_stage = live_stage
         self._live_router = live_router
-        self._stage = shadow_stage
-        self._router = shadow_router
+        self._previous_stage = previous_stage
+        self._previous_router = previous_router
 
-    def prepare_incremental(
+    def prepare_delivery(
         self,
         records: Sequence[ReceivedEvent],
         layer_stack_states: Sequence[dict],
@@ -250,26 +250,26 @@ class _LayeredProjectionShadow:
         force_full: bool,
     ) -> None:
         """Stage the authored batch that a successful commit should mirror."""
-        self._incremental_prepared = True
-        self._pending_incremental = (
+        self._delivery_prepared = True
+        self._pending_delivery = (
             None
             if force_full
             else (tuple(records), tuple(layer_stack_states))
         )
 
-    def advance(self) -> None:
-        """Advance to the live authored state after native adapter success."""
+    def advance_after_delivery(self) -> None:
+        """Advance after the pending native adapter delivery succeeds."""
         try:
-            if self._incremental_prepared and self._pending_incremental is not None:
-                records, layer_stack_states = self._pending_incremental
-                self._advance_incremental(records, layer_stack_states)
+            if self._delivery_prepared and self._pending_delivery is not None:
+                records, layer_stack_states = self._pending_delivery
+                self._apply_pending_delivery(records, layer_stack_states)
             else:
-                self._advance_full()
+                self._copy_full_live_state()
         finally:
-            self._incremental_prepared = False
-            self._pending_incremental = None
+            self._delivery_prepared = False
+            self._pending_delivery = None
 
-    def _advance_incremental(
+    def _apply_pending_delivery(
         self,
         records: Sequence[ReceivedEvent],
         layer_stack_states: Sequence[dict],
@@ -281,18 +281,18 @@ class _LayeredProjectionShadow:
 
         live_stage = self._live_stage
         live_router = self._live_router
-        shadow_stage = self._stage
-        shadow_router = self._router
+        previous_stage = self._previous_stage
+        previous_router = self._previous_router
         if (
             live_stage is None
-            or shadow_stage is None
+            or previous_stage is None
             or not isinstance(live_router, LogicalLayerRouter)
-            or not isinstance(shadow_router, LogicalLayerRouter)
+            or not isinstance(previous_router, LogicalLayerRouter)
         ):
-            raise RuntimeError("projection shadow is not bound")
+            raise RuntimeError("layered previous stage is not bound")
 
         for state in layer_stack_states:
-            shadow_router.apply_state(state)
+            previous_router.apply_state(state)
 
         routed = []
         update_load_rules = False
@@ -302,7 +302,7 @@ class _LayeredProjectionShadow:
             layer = (
                 None
                 if kind in NON_COLLABORATION_KINDS
-                else shadow_router.layer_for(record.layer_key)
+                else previous_router.layer_for(record.layer_key)
             )
             routed.append((layer, event))
             update_load_rules |= kind in {
@@ -311,9 +311,9 @@ class _LayeredProjectionShadow:
                 K_UNLOAD_PAYLOAD,
             }
 
-        stage_adapter = UsdStageAdapter(shadow_stage)
+        stage_adapter = UsdStageAdapter(previous_stage)
         layers = {layer.identifier: layer for layer, _event in routed if layer is not None}
-        with shadow_router.writable(layers.values()):
+        with previous_router.writable(layers.values()):
             start = 0
             while start < len(routed):
                 layer = routed[start][0]
@@ -322,16 +322,16 @@ class _LayeredProjectionShadow:
                     end += 1
                 run = [event for _layer, event in routed[start:end]]
                 edit_target = Usd.EditTarget(
-                    shadow_stage.GetSessionLayer() if layer is None else layer
+                    previous_stage.GetSessionLayer() if layer is None else layer
                 )
-                with Usd.EditContext(shadow_stage, edit_target):
+                with Usd.EditContext(previous_stage, edit_target):
                     stage_adapter.apply_events(run)
                 start = end
 
         if update_load_rules:
-            shadow_stage.SetLoadRules(live_stage.GetLoadRules())
+            previous_stage.SetLoadRules(live_stage.GetLoadRules())
 
-    def _advance_full(self) -> None:
+    def _copy_full_live_state(self) -> None:
         from pxr import Sdf
 
         from ._managed_sublayers import replace_managed_sublayers
@@ -339,39 +339,39 @@ class _LayeredProjectionShadow:
 
         live_stage = self._live_stage
         live_router = self._live_router
-        shadow_stage = self._stage
-        shadow_router = self._router
+        previous_stage = self._previous_stage
+        previous_router = self._previous_router
         if (
             live_stage is None
-            or shadow_stage is None
+            or previous_stage is None
             or not isinstance(live_router, LogicalLayerRouter)
-            or not isinstance(shadow_router, LogicalLayerRouter)
+            or not isinstance(previous_router, LogicalLayerRouter)
         ):
-            raise RuntimeError("projection shadow is not bound")
+            raise RuntimeError("layered previous stage is not bound")
 
-        shadow_session = shadow_stage.GetSessionLayer()
+        previous_session = previous_stage.GetSessionLayer()
         managed_identifiers = (
-            live_router.layer_identifiers | shadow_router.layer_identifiers
+            live_router.layer_identifiers | previous_router.layer_identifiers
         )
         with Sdf.ChangeBlock():
-            shadow_session.TransferContent(live_stage.GetSessionLayer())
+            previous_session.TransferContent(live_stage.GetSessionLayer())
             replace_managed_sublayers(
-                shadow_session,
+                previous_session,
                 [],
                 managed_identifiers,
             )
-        shadow_router.synchronize_from(live_router)
-        shadow_stage.SetLoadRules(live_stage.GetLoadRules())
+        previous_router.synchronize_from(live_router)
+        previous_stage.SetLoadRules(live_stage.GetLoadRules())
 
     def close(self) -> None:
-        if self._router is not None:
-            self._router.close()
+        if self._previous_router is not None:
+            self._previous_router.close()
         self._live_stage = None
         self._live_router = None
-        self._stage = None
-        self._router = None
-        self._incremental_prepared = False
-        self._pending_incremental = None
+        self._previous_stage = None
+        self._previous_router = None
+        self._delivery_prepared = False
+        self._pending_delivery = None
 
 
 def _asset_paths(event: dict) -> tuple[str, ...]:
@@ -487,7 +487,7 @@ class EventDispatcher:
         self._layer_router: LayerKeyRouter | None = None
         self._shared_stage = _SharedStageBinding()
         self._projection_state = None
-        self._projection_shadow: _LayeredProjectionShadow | None = None
+        self._layered_previous_stage: _LayeredPreviousStage | None = None
 
     @property
     def last_seq(self) -> int:
@@ -581,9 +581,9 @@ class EventDispatcher:
             if self._projection_state is not None:
                 self._projection_state.close()
                 self._projection_state = None
-            if self._projection_shadow is not None:
-                self._projection_shadow.close()
-                self._projection_shadow = None
+            if self._layered_previous_stage is not None:
+                self._layered_previous_stage.close()
+                self._layered_previous_stage = None
 
     def _sync_layer_router(self) -> None:
         """Match the local router to the receiver's negotiated capability."""
@@ -620,21 +620,25 @@ class EventDispatcher:
                 self._projection_state.bind(stage)
             return self._projection_state
 
-        if self._projection_shadow is None:
-            self._projection_shadow = _LayeredProjectionShadow()
-        self._projection_shadow.bind(stage, router)
-        shadow_stage = self._projection_shadow.stage
+        if self._layered_previous_stage is None:
+            self._layered_previous_stage = _LayeredPreviousStage()
+        self._layered_previous_stage.bind(stage, router)
+        previous_stage = self._layered_previous_stage.previous_stage
         if self._projection_state is None:
             self._projection_state = ComposedProjectionState(
                 stage,
-                shadow_stage=shadow_stage,
-                advance_shadow=self._projection_shadow.advance,
+                previous_stage=previous_stage,
+                advance_previous_stage=(
+                    self._layered_previous_stage.advance_after_delivery
+                ),
             )
         else:
             self._projection_state.bind(
                 stage,
-                shadow_stage=shadow_stage,
-                advance_shadow=self._projection_shadow.advance,
+                previous_stage=previous_stage,
+                advance_previous_stage=(
+                    self._layered_previous_stage.advance_after_delivery
+                ),
             )
         return self._projection_state
 
@@ -671,8 +675,8 @@ class EventDispatcher:
             else ((), ())
         )
         projection_state = self._native_projection_state(stage) if projects_to_native else None
-        if projects_to_native and self._projection_shadow is not None:
-            self._projection_shadow.prepare_incremental(
+        if projects_to_native and self._layered_previous_stage is not None:
+            self._layered_previous_stage.prepare_delivery(
                 records,
                 layer_stack_states,
                 force_full=(
@@ -703,7 +707,7 @@ class EventDispatcher:
 
         suppress_ctx = self.emitter.suppressed() if self.emitter else nullcontext()
         projection_ctx = projection if projection is not None else nullcontext()
-        projected: list[dict] = []
+        native_adapter_events: list[dict] = []
         with projection_ctx, suppress_ctx:
             if reset_layers:
                 self._shared_stage.reset()
@@ -750,12 +754,14 @@ class EventDispatcher:
             self._shared_stage.remember(shared_state_events)
 
             if projection is not None:
-                projected = projection.build_events()
-                if projected:
-                    self.adapter.apply_events(projected)
+                native_adapter_events = projection.build_events()
+                if native_adapter_events:
+                    self.adapter.apply_events(native_adapter_events)
                 projection.commit()
 
-            adapter_events = projected if projection is not None else events
+            adapter_events = (
+                native_adapter_events if projection is not None else events
+            )
             if self.on_imported is not None:
                 imported = [
                     event["prim"]
@@ -770,7 +776,7 @@ class EventDispatcher:
                 applied = [event["prim"] for event in adapter_events if event.get("prim")]
                 if applied:
                     self.on_applied(applied)
-        return len(projected) if projection is not None else len(events)
+        return len(native_adapter_events) if projection is not None else len(events)
 
     def _apply(self, events: list[dict]) -> int:
         """Run the apply pipeline on a pre-decoded batch.

--- a/openusdconnect/dispatcher.py
+++ b/openusdconnect/dispatcher.py
@@ -181,6 +181,199 @@ class _SharedStageBinding:
             self._events[new_key] = event
 
 
+class _LayeredProjectionShadow:
+    """Independent last-successful stage for native composed projection."""
+
+    def __init__(self):
+        self._live_stage: Usd.Stage | None = None
+        self._live_router: LayerKeyRouter | None = None
+        self._stage: Usd.Stage | None = None
+        self._router: LayerKeyRouter | None = None
+        self._incremental_prepared = False
+        self._pending_incremental = None
+
+    @property
+    def stage(self) -> Usd.Stage:
+        if self._stage is None:
+            raise RuntimeError("projection shadow is not bound")
+        return self._stage
+
+    def bind(self, live_stage: Usd.Stage, live_router: LayerKeyRouter) -> None:
+        if live_stage is self._live_stage and live_router is self._live_router:
+            shadow_stage = self.stage
+            population_mask = live_stage.GetPopulationMask()
+            if shadow_stage.GetPopulationMask() != population_mask:
+                shadow_stage.SetPopulationMask(population_mask)
+            load_rules = live_stage.GetLoadRules()
+            if shadow_stage.GetLoadRules() != load_rules:
+                shadow_stage.SetLoadRules(load_rules)
+            return
+        from pxr import Sdf, Usd
+
+        from ._managed_sublayers import replace_managed_sublayers
+        from .logical_layers import LogicalLayerRouter
+
+        self.close()
+        if not isinstance(live_router, LogicalLayerRouter):
+            raise TypeError("layered native projection requires a LogicalLayerRouter")
+
+        shadow_session = Sdf.Layer.CreateAnonymous("native-projection-shadow-session.usda")
+        shadow_session.TransferContent(live_stage.GetSessionLayer())
+        replace_managed_sublayers(
+            shadow_session,
+            [],
+            live_router.layer_identifiers,
+        )
+        shadow_stage = Usd.Stage.OpenMasked(
+            live_stage.GetRootLayer(),
+            shadow_session,
+            live_stage.GetPathResolverContext(),
+            live_stage.GetPopulationMask(),
+            Usd.Stage.LoadNone,
+        )
+        if shadow_stage is None:
+            raise RuntimeError("could not open native projection shadow stage")
+        shadow_router = LogicalLayerRouter(shadow_stage)
+        shadow_router.synchronize_from(live_router)
+        shadow_stage.SetLoadRules(live_stage.GetLoadRules())
+
+        self._live_stage = live_stage
+        self._live_router = live_router
+        self._stage = shadow_stage
+        self._router = shadow_router
+
+    def prepare_incremental(
+        self,
+        records: Sequence[ReceivedEvent],
+        layer_stack_states: Sequence[dict],
+        *,
+        force_full: bool,
+    ) -> None:
+        """Stage the authored batch that a successful commit should mirror."""
+        self._incremental_prepared = True
+        self._pending_incremental = (
+            None
+            if force_full
+            else (tuple(records), tuple(layer_stack_states))
+        )
+
+    def advance(self) -> None:
+        """Advance to the live authored state after native adapter success."""
+        try:
+            if self._incremental_prepared and self._pending_incremental is not None:
+                records, layer_stack_states = self._pending_incremental
+                self._advance_incremental(records, layer_stack_states)
+            else:
+                self._advance_full()
+        finally:
+            self._incremental_prepared = False
+            self._pending_incremental = None
+
+    def _advance_incremental(
+        self,
+        records: Sequence[ReceivedEvent],
+        layer_stack_states: Sequence[dict],
+    ) -> None:
+        from pxr import Usd
+
+        from .adapters import UsdStageAdapter
+        from .logical_layers import LogicalLayerRouter
+
+        live_stage = self._live_stage
+        live_router = self._live_router
+        shadow_stage = self._stage
+        shadow_router = self._router
+        if (
+            live_stage is None
+            or shadow_stage is None
+            or not isinstance(live_router, LogicalLayerRouter)
+            or not isinstance(shadow_router, LogicalLayerRouter)
+        ):
+            raise RuntimeError("projection shadow is not bound")
+
+        for state in layer_stack_states:
+            shadow_router.apply_state(state)
+
+        routed = []
+        update_load_rules = False
+        for record in records:
+            event = record.event
+            kind = event.get("k")
+            layer = (
+                None
+                if kind in NON_COLLABORATION_KINDS
+                else shadow_router.layer_for(record.layer_key)
+            )
+            routed.append((layer, event))
+            update_load_rules |= kind in {
+                K_LOAD_PAYLOAD,
+                K_RENAME_PRIM,
+                K_UNLOAD_PAYLOAD,
+            }
+
+        stage_adapter = UsdStageAdapter(shadow_stage)
+        layers = {layer.identifier: layer for layer, _event in routed if layer is not None}
+        with shadow_router.writable(layers.values()):
+            start = 0
+            while start < len(routed):
+                layer = routed[start][0]
+                end = start + 1
+                while end < len(routed) and routed[end][0] is layer:
+                    end += 1
+                run = [event for _layer, event in routed[start:end]]
+                edit_target = Usd.EditTarget(
+                    shadow_stage.GetSessionLayer() if layer is None else layer
+                )
+                with Usd.EditContext(shadow_stage, edit_target):
+                    stage_adapter.apply_events(run)
+                start = end
+
+        if update_load_rules:
+            shadow_stage.SetLoadRules(live_stage.GetLoadRules())
+
+    def _advance_full(self) -> None:
+        from pxr import Sdf
+
+        from ._managed_sublayers import replace_managed_sublayers
+        from .logical_layers import LogicalLayerRouter
+
+        live_stage = self._live_stage
+        live_router = self._live_router
+        shadow_stage = self._stage
+        shadow_router = self._router
+        if (
+            live_stage is None
+            or shadow_stage is None
+            or not isinstance(live_router, LogicalLayerRouter)
+            or not isinstance(shadow_router, LogicalLayerRouter)
+        ):
+            raise RuntimeError("projection shadow is not bound")
+
+        shadow_session = shadow_stage.GetSessionLayer()
+        managed_identifiers = (
+            live_router.layer_identifiers | shadow_router.layer_identifiers
+        )
+        with Sdf.ChangeBlock():
+            shadow_session.TransferContent(live_stage.GetSessionLayer())
+            replace_managed_sublayers(
+                shadow_session,
+                [],
+                managed_identifiers,
+            )
+        shadow_router.synchronize_from(live_router)
+        shadow_stage.SetLoadRules(live_stage.GetLoadRules())
+
+    def close(self) -> None:
+        if self._router is not None:
+            self._router.close()
+        self._live_stage = None
+        self._live_router = None
+        self._stage = None
+        self._router = None
+        self._incremental_prepared = False
+        self._pending_incremental = None
+
+
 def _asset_paths(event: dict) -> tuple[str, ...]:
     kind = event.get("k")
     entries = event.get("refs", ()) if kind == K_SET_REFERENCE else event.get("payloads", ())
@@ -294,6 +487,7 @@ class EventDispatcher:
         self._layer_router: LayerKeyRouter | None = None
         self._shared_stage = _SharedStageBinding()
         self._projection_state = None
+        self._projection_shadow: _LayeredProjectionShadow | None = None
 
     @property
     def last_seq(self) -> int:
@@ -364,7 +558,7 @@ class EventDispatcher:
             self._layer_router.bind(stage)
             self._shared_stage.bind(stage)
             if self._projection_state is not None:
-                self._projection_state.bind(stage)
+                self._native_projection_state(stage)
 
     def unbind_stage(self) -> None:
         """Detach managed layers without closing the dispatcher.
@@ -387,6 +581,9 @@ class EventDispatcher:
             if self._projection_state is not None:
                 self._projection_state.close()
                 self._projection_state = None
+            if self._projection_shadow is not None:
+                self._projection_shadow.close()
+                self._projection_shadow = None
 
     def _sync_layer_router(self) -> None:
         """Match the local router to the receiver's negotiated capability."""
@@ -415,10 +612,30 @@ class EventDispatcher:
     def _native_projection_state(self, stage: Usd.Stage):
         from .composed_projection import ComposedProjectionState
 
+        router = self._layer_router
+        if router is None:
+            if self._projection_state is None:
+                self._projection_state = ComposedProjectionState(stage)
+            else:
+                self._projection_state.bind(stage)
+            return self._projection_state
+
+        if self._projection_shadow is None:
+            self._projection_shadow = _LayeredProjectionShadow()
+        self._projection_shadow.bind(stage, router)
+        shadow_stage = self._projection_shadow.stage
         if self._projection_state is None:
-            self._projection_state = ComposedProjectionState(stage)
+            self._projection_state = ComposedProjectionState(
+                stage,
+                shadow_stage=shadow_stage,
+                advance_shadow=self._projection_shadow.advance,
+            )
         else:
-            self._projection_state.bind(stage)
+            self._projection_state.bind(
+                stage,
+                shadow_stage=shadow_stage,
+                advance_shadow=self._projection_shadow.advance,
+            )
         return self._projection_state
 
     def _apply_layered(
@@ -453,11 +670,21 @@ class EventDispatcher:
             if reset_layers or layer_stack_states
             else ((), ())
         )
+        projection_state = self._native_projection_state(stage) if projects_to_native else None
+        if projects_to_native and self._projection_shadow is not None:
+            self._projection_shadow.prepare_incremental(
+                records,
+                layer_stack_states,
+                force_full=(
+                    reset_layers
+                    or bool(projection_state and projection_state.needs_full_reconcile)
+                ),
+            )
         projection = (
             ComposedChangeProjection(
                 stage,
                 events,
-                state=self._native_projection_state(stage),
+                state=projection_state,
                 extra_scene_paths=stack_paths,
                 extra_arc_candidates=stack_arc_paths,
                 reapply_composed_paths=same_origin_paths,

--- a/openusdconnect/dispatcher.py
+++ b/openusdconnect/dispatcher.py
@@ -131,9 +131,7 @@ class _SharedStageBinding:
         self._session_fields = {
             field: (
                 pseudo_root.HasInfo(field),
-                copy.deepcopy(pseudo_root.GetInfo(field))
-                if pseudo_root.HasInfo(field)
-                else None,
+                copy.deepcopy(pseudo_root.GetInfo(field)) if pseudo_root.HasInfo(field) else None,
             )
             for field in STAGE_METADATA_KEYS
         }
@@ -295,6 +293,7 @@ class EventDispatcher:
         self._asset_events: dict[tuple[str, str, str], _TrackedAssetEvent] = {}
         self._layer_router: LayerKeyRouter | None = None
         self._shared_stage = _SharedStageBinding()
+        self._projection_state = None
 
     @property
     def last_seq(self) -> int:
@@ -364,6 +363,8 @@ class EventDispatcher:
         with suppress_ctx:
             self._layer_router.bind(stage)
             self._shared_stage.bind(stage)
+            if self._projection_state is not None:
+                self._projection_state.bind(stage)
 
     def unbind_stage(self) -> None:
         """Detach managed layers without closing the dispatcher.
@@ -383,6 +384,9 @@ class EventDispatcher:
             self._shared_stage.close()
             if self._layer_router is not None:
                 self._layer_router.close()
+            if self._projection_state is not None:
+                self._projection_state.close()
+                self._projection_state = None
 
     def _sync_layer_router(self) -> None:
         """Match the local router to the receiver's negotiated capability."""
@@ -407,6 +411,15 @@ class EventDispatcher:
         router.bind(stage)
         self._shared_stage.bind(stage)
         return stage
+
+    def _native_projection_state(self, stage: Usd.Stage):
+        from .composed_projection import ComposedProjectionState
+
+        if self._projection_state is None:
+            self._projection_state = ComposedProjectionState(stage)
+        else:
+            self._projection_state.bind(stage)
+        return self._projection_state
 
     def _apply_layered(
         self,
@@ -444,6 +457,7 @@ class EventDispatcher:
             ComposedChangeProjection(
                 stage,
                 events,
+                state=self._native_projection_state(stage),
                 extra_scene_paths=stack_paths,
                 extra_arc_candidates=stack_arc_paths,
                 reapply_composed_paths=same_origin_paths,
@@ -461,8 +475,9 @@ class EventDispatcher:
             self._observe_asset_dependencies(run, edit_target=edit_target)
 
         suppress_ctx = self.emitter.suppressed() if self.emitter else nullcontext()
+        projection_ctx = projection if projection is not None else nullcontext()
         projected: list[dict] = []
-        with suppress_ctx:
+        with projection_ctx, suppress_ctx:
             if reset_layers:
                 self._shared_stage.reset()
                 router.clear()
@@ -511,6 +526,7 @@ class EventDispatcher:
                 projected = projection.build_events()
                 if projected:
                     self.adapter.apply_events(projected)
+                projection.commit()
 
             adapter_events = projected if projection is not None else events
             if self.on_imported is not None:
@@ -977,6 +993,7 @@ class EventDispatcher:
             projection = ComposedChangeProjection(
                 stage,
                 adapter_events,
+                state=self._native_projection_state(stage),
                 reapply_all_composed=True,
             )
         # A dependency can have been received while any local layer or mapped
@@ -985,6 +1002,8 @@ class EventDispatcher:
         # Snapshot every affected layer before mutating any of them so a stage
         # adapter failure rolls the complete multi-layer replay back.
         with ExitStack() as transaction:
+            if projection is not None:
+                transaction.enter_context(projection)
             snapshotted_layers: set[str] = set()
             for tracked_event, _local_events in replays:
                 layer = tracked_event.edit_target.GetLayer()
@@ -1013,13 +1032,14 @@ class EventDispatcher:
                     else:
                         apply_events(stage, local_events)
 
-        # DCC adapters consume the same events only after the mirror stage has
-        # committed. They do not expose USD edit targets themselves.
-        if not adapter_handles_stage:
-            assert projection is not None
-            adapter_events = projection.build_events()
-            if adapter_events:
-                self.adapter.apply_events(adapter_events)
+            # DCC adapters consume the same events only after the mirror stage
+            # has committed. They do not expose USD edit targets themselves.
+            if not adapter_handles_stage:
+                assert projection is not None
+                adapter_events = projection.build_events()
+                if adapter_events:
+                    self.adapter.apply_events(adapter_events)
+                projection.commit()
 
         for tracked_event, local_events in replays:
             if self.emitter is not None:

--- a/openusdconnect/dispatcher.py
+++ b/openusdconnect/dispatcher.py
@@ -182,7 +182,12 @@ class _SharedStageBinding:
 
 
 class _LayeredPreviousStage:
-    """Last layered USD state successfully delivered to a native adapter."""
+    """Last layered USD state successfully delivered to a native adapter.
+
+    The immutable base root is shared for low-cost composition. A live change
+    to a context-dependent resolver mapping therefore requires dispatcher
+    recreation, stage rebind, or destructive native-scene rebuild.
+    """
 
     def __init__(self):
         self._live_stage: Usd.Stage | None = None
@@ -510,6 +515,8 @@ class EventDispatcher:
         """
         if self.adapter is None:
             return 0
+        if self._projection_state is not None:
+            self._projection_state.ensure_native_projection_safe()
         bufs = self.receiver.drain_queue()
         if not bufs:
             return 0
@@ -559,6 +566,20 @@ class EventDispatcher:
             self._shared_stage.bind(stage)
             if self._projection_state is not None:
                 self._native_projection_state(stage)
+
+    @property
+    def native_scene_rebuild_required(self) -> bool:
+        """Whether resolver refresh made incremental native delivery unsafe."""
+        return bool(
+            self._projection_state
+            and self._projection_state.native_scene_rebuild_required
+        )
+
+    def acknowledge_native_scene_rebuilt(self) -> None:
+        """Advance the baseline and resume after native state reconstruction."""
+        if self._projection_state is None:
+            return
+        self._projection_state.acknowledge_native_scene_rebuilt()
 
     def unbind_stage(self) -> None:
         """Detach managed layers without closing the dispatcher.
@@ -631,6 +652,7 @@ class EventDispatcher:
                 advance_previous_stage=(
                     self._layered_previous_stage.advance_after_delivery
                 ),
+                resolver_refresh_requires_native_rebuild=True,
             )
         else:
             self._projection_state.bind(
@@ -639,6 +661,7 @@ class EventDispatcher:
                 advance_previous_stage=(
                     self._layered_previous_stage.advance_after_delivery
                 ),
+                resolver_refresh_requires_native_rebuild=True,
             )
         return self._projection_state
 
@@ -660,9 +683,11 @@ class EventDispatcher:
             raise RuntimeError("layered replay was not negotiated")
         stage = self._bind_layer_router()
         events = [record.event for record in records]
-        adapter_stage = self.adapter.targets_stage()
-        projects_to_native = adapter_stage is not stage
-        stage_adapter = UsdStageAdapter(stage) if projects_to_native else self.adapter
+        adapter_writes_to_mirror_stage = self.adapter.targets_stage() is stage
+        projects_to_external_scene = not adapter_writes_to_mirror_stage
+        stage_adapter = (
+            UsdStageAdapter(stage) if projects_to_external_scene else self.adapter
+        )
         local_origin = getattr(self.receiver, "origin", None)
         same_origin_paths = {
             str(record.event["prim"])
@@ -674,8 +699,12 @@ class EventDispatcher:
             if reset_layers or layer_stack_states
             else ((), ())
         )
-        projection_state = self._native_projection_state(stage) if projects_to_native else None
-        if projects_to_native and self._layered_previous_stage is not None:
+        projection_state = (
+            self._native_projection_state(stage)
+            if projects_to_external_scene
+            else None
+        )
+        if projects_to_external_scene and self._layered_previous_stage is not None:
             self._layered_previous_stage.prepare_delivery(
                 records,
                 layer_stack_states,
@@ -694,7 +723,7 @@ class EventDispatcher:
                 reapply_composed_paths=same_origin_paths,
                 reset=reset_layers,
             )
-            if projects_to_native
+            if projects_to_external_scene
             else None
         )
 

--- a/openusdconnect/logical_layers.py
+++ b/openusdconnect/logical_layers.py
@@ -31,6 +31,43 @@ class LogicalLayerRouter(LayerKeyRouter):
     def layer_keys(self) -> tuple[str, ...]:
         return self._layer_keys
 
+    @property
+    def layer_identifiers(self) -> frozenset[str]:
+        """Identifiers of the anonymous layers owned by this router."""
+        return frozenset(self._managed_identifiers())
+
+    def synchronize_from(self, source: LogicalLayerRouter) -> None:
+        """Replace this router's topology and contents with ``source``.
+
+        Destination layers remain independent anonymous layers.  Public
+        ``Sdf.Layer.TransferContent`` advances a projection shadow without
+        retaining a Python snapshot for every composed prim.
+        """
+        if not isinstance(source, LogicalLayerRouter):
+            raise TypeError("source must be a LogicalLayerRouter")
+        if source is self:
+            return
+
+        for layer_key in source._layer_keys:
+            if layer_key not in self._layers:
+                layer = self._create_layer(layer_key, layer_key)
+                self._layers[layer_key] = layer
+                self._keys_by_identifier[layer.identifier] = layer_key
+            self._layers[layer_key].TransferContent(source._layers[layer_key])
+
+        self._layer_keys = source._layer_keys
+        self._muted = dict(source._muted)
+        removed_keys = set(self._layers) - set(self._layer_keys)
+        if self._stage is not None:
+            self._install_layers(self._stage)
+        for layer_key in removed_keys:
+            layer = self._layers.pop(layer_key)
+            self._keys_by_identifier.pop(layer.identifier, None)
+
+        self._generation = source._generation
+        self._revision = source._revision
+        self._ready = source._ready
+
     def layer_for(self, layer_key: str) -> Sdf.Layer:
         """Return the receiver-local layer for one routed event."""
         if not self._ready:

--- a/scripts/benchmark_composed_projection_state.py
+++ b/scripts/benchmark_composed_projection_state.py
@@ -1,0 +1,128 @@
+"""Profile persistent composed projection state against a real USD asset.
+
+Examples::
+
+    python scripts/benchmark_composed_projection_state.py ASSET baseline --iterations 20
+    python scripts/benchmark_composed_projection_state.py ASSET noop --iterations 1000
+    python scripts/benchmark_composed_projection_state.py ASSET sparse --iterations 1000
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import statistics
+import time
+import tracemalloc
+from pathlib import Path
+
+from pxr import Usd, UsdGeom
+
+from openusdconnect.composed_projection import (
+    ComposedChangeProjection,
+    ComposedProjectionState,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("asset", type=Path)
+    parser.add_argument("phase", choices=("baseline", "memory", "noop", "sparse"))
+    parser.add_argument("--iterations", type=int, default=100)
+    return parser.parse_args()
+
+
+def _measure(operation, iterations: int) -> list[float]:
+    samples = []
+    for _ in range(iterations):
+        start = time.perf_counter_ns()
+        operation()
+        samples.append((time.perf_counter_ns() - start) / 1_000_000)
+    return samples
+
+
+def _print_samples(samples: list[float]) -> None:
+    ordered = sorted(samples)
+    p95 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.95))]
+    print(
+        f"median={statistics.median(samples):.3f} ms "
+        f"p95={p95:.3f} ms min={ordered[0]:.3f} ms max={ordered[-1]:.3f} ms"
+    )
+
+
+def main() -> None:
+    args = _parse_args()
+    asset = args.asset.resolve()
+    if args.iterations <= 0:
+        raise ValueError("--iterations must be positive")
+
+    if args.phase == "baseline":
+        stage = Usd.Stage.Open(str(asset))
+        if stage is None:
+            raise RuntimeError(f"could not open {asset}")
+
+        def baseline() -> None:
+            state = ComposedProjectionState(stage)
+            state.close()
+
+        samples = _measure(baseline, args.iterations)
+        gc.collect()
+        _print_samples(samples)
+        return
+
+    if args.phase == "memory":
+        stage = Usd.Stage.Open(str(asset))
+        if stage is None:
+            raise RuntimeError(f"could not open {asset}")
+        gc.collect()
+        tracemalloc.start()
+        state = ComposedProjectionState(stage)
+        gc.collect()
+        with_state = tracemalloc.get_traced_memory()[0]
+        state.close()
+        del state
+        gc.collect()
+        after_close = tracemalloc.get_traced_memory()[0]
+        print(f"retained={(with_state - after_close) / (1024 * 1024):.3f} MiB")
+        return
+
+    stage = Usd.Stage.Open(str(asset))
+    if stage is None:
+        raise RuntimeError(f"could not open {asset}")
+    state = ComposedProjectionState(stage)
+
+    if args.phase == "noop":
+        def transaction() -> None:
+            with ComposedChangeProjection(stage, [], state=state) as projection:
+                if projection.build_events():
+                    raise RuntimeError("no-op projection produced events")
+                projection.commit()
+
+    else:
+        imageable = next(
+            (UsdGeom.Imageable(prim) for prim in stage.Traverse() if UsdGeom.Imageable(prim)),
+            None,
+        )
+        if imageable is None:
+            raise RuntimeError(f"{asset} has no imageable prim")
+        stage.SetEditTarget(stage.GetSessionLayer())
+        visibility = imageable.GetVisibilityAttr()
+        invisible = False
+
+        def transaction() -> None:
+            nonlocal invisible
+            invisible = not invisible
+            value = UsdGeom.Tokens.invisible if invisible else UsdGeom.Tokens.inherited
+            with ComposedChangeProjection(stage, [], state=state) as projection:
+                visibility.Set(value)
+                projected = projection.build_events()
+                if len(projected) != 1:
+                    raise RuntimeError(f"sparse projection produced {len(projected)} events")
+                projection.commit()
+
+    samples = _measure(transaction, args.iterations)
+    _print_samples(samples)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_composed_projection_state.py
+++ b/scripts/benchmark_composed_projection_state.py
@@ -2,7 +2,8 @@
 
 Examples::
 
-    python scripts/benchmark_composed_projection_state.py ASSET baseline --iterations 20
+    python scripts/benchmark_composed_projection_state.py ASSET startup --iterations 20
+    python scripts/benchmark_composed_projection_state.py ASSET memory
     python scripts/benchmark_composed_projection_state.py ASSET noop --iterations 1000
     python scripts/benchmark_composed_projection_state.py ASSET sparse --iterations 1000
 """
@@ -10,6 +11,7 @@ Examples::
 from __future__ import annotations
 
 import argparse
+import ctypes
 import gc
 import statistics
 import time
@@ -27,7 +29,11 @@ from openusdconnect.composed_projection import (
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("asset", type=Path)
-    parser.add_argument("phase", choices=("baseline", "memory", "noop", "sparse"))
+    parser.add_argument(
+        "phase",
+        choices=("startup", "baseline", "memory", "noop", "sparse"),
+        help="'baseline' is a deprecated alias for 'startup'",
+    )
     parser.add_argument("--iterations", type=int, default=100)
     return parser.parse_args()
 
@@ -50,22 +56,61 @@ def _print_samples(samples: list[float]) -> None:
     )
 
 
+def _process_memory_bytes() -> tuple[int, int] | None:
+    if not hasattr(ctypes, "windll"):
+        return None
+
+    class ProcessMemoryCountersEx(ctypes.Structure):
+        _fields_ = [
+            ("cb", ctypes.c_ulong),
+            ("page_fault_count", ctypes.c_ulong),
+            ("peak_working_set_size", ctypes.c_size_t),
+            ("working_set_size", ctypes.c_size_t),
+            ("quota_peak_paged_pool_usage", ctypes.c_size_t),
+            ("quota_paged_pool_usage", ctypes.c_size_t),
+            ("quota_peak_non_paged_pool_usage", ctypes.c_size_t),
+            ("quota_non_paged_pool_usage", ctypes.c_size_t),
+            ("pagefile_usage", ctypes.c_size_t),
+            ("peak_pagefile_usage", ctypes.c_size_t),
+            ("private_usage", ctypes.c_size_t),
+        ]
+
+    counters = ProcessMemoryCountersEx()
+    counters.cb = ctypes.sizeof(counters)
+    get_current_process = ctypes.windll.kernel32.GetCurrentProcess
+    get_current_process.restype = ctypes.c_void_p
+    get_process_memory_info = ctypes.windll.psapi.GetProcessMemoryInfo
+    get_process_memory_info.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ProcessMemoryCountersEx),
+        ctypes.c_ulong,
+    ]
+    get_process_memory_info.restype = ctypes.c_int
+    if not get_process_memory_info(
+        get_current_process(),
+        ctypes.byref(counters),
+        counters.cb,
+    ):
+        raise ctypes.WinError()
+    return counters.working_set_size, counters.private_usage
+
+
 def main() -> None:
     args = _parse_args()
     asset = args.asset.resolve()
     if args.iterations <= 0:
         raise ValueError("--iterations must be positive")
 
-    if args.phase == "baseline":
+    if args.phase in {"startup", "baseline"}:
         stage = Usd.Stage.Open(str(asset))
         if stage is None:
             raise RuntimeError(f"could not open {asset}")
 
-        def baseline() -> None:
+        def startup() -> None:
             state = ComposedProjectionState(stage)
             state.close()
 
-        samples = _measure(baseline, args.iterations)
+        samples = _measure(startup, args.iterations)
         gc.collect()
         _print_samples(samples)
         return
@@ -75,15 +120,25 @@ def main() -> None:
         if stage is None:
             raise RuntimeError(f"could not open {asset}")
         gc.collect()
+        process_before = _process_memory_bytes()
         tracemalloc.start()
         state = ComposedProjectionState(stage)
         gc.collect()
+        process_with_state = _process_memory_bytes()
         with_state = tracemalloc.get_traced_memory()[0]
         state.close()
         del state
         gc.collect()
         after_close = tracemalloc.get_traced_memory()[0]
-        print(f"retained={(with_state - after_close) / (1024 * 1024):.3f} MiB")
+        print(f"python_heap={(with_state - after_close) / (1024 * 1024):.3f} MiB")
+        if process_before is not None and process_with_state is not None:
+            print(
+                "process_increment="
+                f"{(process_with_state[0] - process_before[0]) / (1024 * 1024):.3f} MiB "
+                "working_set, "
+                f"{(process_with_state[1] - process_before[1]) / (1024 * 1024):.3f} MiB "
+                "private"
+            )
         return
 
     stage = Usd.Stage.Open(str(asset))

--- a/tests/unit/test_composed_projection.py
+++ b/tests/unit/test_composed_projection.py
@@ -12,11 +12,12 @@ import pxr
 import pytest
 from pxr import Sdf, Usd, UsdGeom, UsdShade, UsdUtils
 
-from openusdconnect.adapters import MockAdapter
+from openusdconnect.adapters import MockAdapter, UsdStageAdapter
 from openusdconnect.codec import encode_message
 from openusdconnect.composed_projection import (
     ComposedChangeProjection,
     ComposedProjectionState,
+    NativeSceneRebuildRequired,
 )
 from openusdconnect.dispatcher import EventDispatcher
 from openusdconnect.event_apply import apply_events
@@ -262,6 +263,112 @@ def test_persistent_projection_state_reconciles_after_adapter_failure():
     with ComposedChangeProjection(stage, [], state=state) as settled:
         assert settled.build_events() == []
         settled.commit()
+
+
+def test_shared_root_projection_pauses_after_resolver_refresh(caplog):
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim("/World", "Xform")
+    previous = Usd.Stage.Open(
+        stage.GetRootLayer(),
+        Sdf.Layer.CreateAnonymous("previous-session.usda"),
+    )
+    baseline_advances = []
+    state = ComposedProjectionState(
+        stage,
+        previous_stage=previous,
+        advance_previous_stage=lambda: baseline_advances.append(True),
+        resolver_refresh_requires_native_rebuild=True,
+    )
+
+    class AffectedNotice:
+        @staticmethod
+        def AffectsContext(_context):
+            return True
+
+    state._on_resolver_changed(AffectedNotice(), None)
+
+    assert state.native_scene_rebuild_required
+    assert "incremental delivery is paused" in caplog.text
+    with pytest.raises(NativeSceneRebuildRequired, match="Recreate the receiver"):
+        ComposedChangeProjection(stage, [], state=state)
+
+    state.acknowledge_native_scene_rebuilt()
+    assert baseline_advances == [True]
+    assert not state.native_scene_rebuild_required
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        projection.commit()
+
+
+def test_dispatcher_does_not_drain_while_native_scene_rebuild_is_required():
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim("/World", "Xform")
+    receiver = _LayeredQueue(
+        [encode_message(_state(1, [(_STRONG_LAYER, "Strong", False)]))]
+    )
+    dispatcher = EventDispatcher(
+        receiver=receiver,
+        adapter=MockAdapter(),
+        mirror_stage=stage,
+    )
+    dispatcher.drain_and_apply()
+    state = dispatcher._projection_state
+
+    class AffectedNotice:
+        @staticmethod
+        def AffectsContext(_context):
+            return True
+
+    state._on_resolver_changed(AffectedNotice(), None)
+    pending = encode_message(_state(2, [(_STRONG_LAYER, "Strong", False)]))
+    receiver.messages = [pending]
+    last_seq = dispatcher.last_seq
+
+    assert dispatcher.native_scene_rebuild_required
+    with pytest.raises(NativeSceneRebuildRequired):
+        dispatcher.drain_and_apply()
+    assert receiver.messages == [pending]
+    assert dispatcher.last_seq == last_seq
+
+    dispatcher.acknowledge_native_scene_rebuilt()
+    assert not dispatcher.native_scene_rebuild_required
+    dispatcher.drain_and_apply()
+    assert receiver.messages == []
+    dispatcher.close()
+
+
+@pytest.mark.parametrize(
+    ("adapter_destination", "expects_composed_projection"),
+    [
+        ("same_stage", False),
+        ("external_scene", True),
+        ("different_stage", True),
+    ],
+)
+def test_adapter_target_stage_identity_selects_composed_projection(
+    adapter_destination,
+    expects_composed_projection,
+):
+    mirror_stage = Usd.Stage.CreateInMemory()
+    mirror_stage.DefinePrim("/World", "Xform")
+    if adapter_destination == "same_stage":
+        adapter = UsdStageAdapter(mirror_stage)
+    elif adapter_destination == "different_stage":
+        adapter = UsdStageAdapter(Usd.Stage.CreateInMemory())
+    else:
+        adapter = MockAdapter()
+
+    receiver = _LayeredQueue(
+        [encode_message(_state(1, [(_STRONG_LAYER, "Strong", False)]))]
+    )
+    dispatcher = EventDispatcher(
+        receiver=receiver,
+        adapter=adapter,
+        mirror_stage=mirror_stage,
+    )
+    dispatcher.drain_and_apply()
+
+    assert (dispatcher._projection_state is not None) is expects_composed_projection
+    dispatcher.close()
 
 
 def test_noop_commit_keeps_owned_previous_stage():

--- a/tests/unit/test_composed_projection.py
+++ b/tests/unit/test_composed_projection.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from pxr import Sdf, Usd, UsdShade
+from pxr import Sdf, Usd, UsdGeom, UsdShade
 
 from openusdconnect.adapters import MockAdapter
 from openusdconnect.codec import encode_message
@@ -287,6 +287,88 @@ def test_persistent_projection_sparse_commit_replaces_only_affected_prim():
 
     assert state.baseline.prims["/World/Changed"] is not changed_before
     assert state.baseline.prims["/World/Untouched"] is untouched_before
+
+
+def test_shadow_projection_state_noop_bind_preserves_shadow_mode():
+    live = Usd.Stage.CreateInMemory()
+    shadow = Usd.Stage.CreateInMemory()
+    state = ComposedProjectionState(
+        live,
+        shadow_stage=shadow,
+        advance_shadow=lambda: None,
+    )
+
+    state.bind(live)
+
+    assert state.shadow_stage is shadow
+    with pytest.raises(RuntimeError, match="shadow mode"):
+        state.baseline.ensure("/World")
+
+
+def test_layered_shadow_advances_only_after_native_adapter_success():
+    class FailingOnceAdapter(MockAdapter):
+        fail_next = False
+
+        def apply_events(self, events):
+            if self.fail_next:
+                self.fail_next = False
+                raise RuntimeError("adapter failed")
+            return super().apply_events(events)
+
+    stage = Usd.Stage.CreateInMemory()
+    receiver = _LayeredQueue(
+        [
+            encode_message(
+                _state(
+                    1,
+                    [(_STRONG_LAYER, "Strong", False)],
+                )
+            ),
+            *_xform_events(1, _STRONG_LAYER, 1.0),
+        ]
+    )
+    adapter = FailingOnceAdapter()
+    dispatcher = EventDispatcher(receiver=receiver, adapter=adapter, mirror_stage=stage)
+    assert dispatcher.drain_and_apply() > 0
+    assert dispatcher._projection_state.shadow_stage is not stage
+
+    adapter.fail_next = True
+    receiver.messages = [
+        _event(
+            4,
+            _STRONG_LAYER,
+            {
+                "k": "set_xform_trs",
+                "prim": "/World/Thing",
+                "fields": ["t"],
+                "t": [2.0, 0.0, 0.0],
+            },
+        )
+    ]
+    with pytest.raises(RuntimeError, match="adapter failed"):
+        dispatcher.drain_and_apply()
+
+    state = dispatcher._projection_state
+    assert state.needs_full_reconcile
+    shadow_prim = state.shadow_stage.GetPrimAtPath("/World/Thing")
+    shadow_matrix = UsdGeom.Xformable(shadow_prim).GetLocalTransformation()
+    assert tuple(shadow_matrix.ExtractTranslation()) == pytest.approx((1.0, 0.0, 0.0))
+
+    receiver.messages = [
+        encode_message(
+            _state(
+                2,
+                [(_STRONG_LAYER, "Strong", False)],
+            )
+        )
+    ]
+    assert dispatcher.drain_and_apply() > 0
+    assert adapter.get_trs("/World/Thing")["t"] == pytest.approx([2.0, 0.0, 0.0])
+    assert not state.needs_full_reconcile
+    shadow_matrix = UsdGeom.Xformable(
+        state.shadow_stage.GetPrimAtPath("/World/Thing")
+    ).GetLocalTransformation()
+    assert tuple(shadow_matrix.ExtractTranslation()) == pytest.approx((2.0, 0.0, 0.0))
 
 
 def test_unknown_event_kind_cannot_bypass_native_projection():

--- a/tests/unit/test_composed_projection.py
+++ b/tests/unit/test_composed_projection.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pxr
 import pytest
-from pxr import Sdf, Usd, UsdGeom, UsdShade
+from pxr import Sdf, Usd, UsdGeom, UsdShade, UsdUtils
 
 from openusdconnect.adapters import MockAdapter
 from openusdconnect.codec import encode_message
@@ -257,36 +264,332 @@ def test_persistent_projection_state_reconciles_after_adapter_failure():
         settled.commit()
 
 
-def test_persistent_projection_noop_commit_keeps_baseline_object():
+def test_persistent_projection_noop_commit_keeps_owned_shadow_stage():
     stage = Usd.Stage.CreateInMemory()
     stage.DefinePrim("/World/Thing", "Sphere")
     state = ComposedProjectionState(stage)
-    baseline = state.baseline
+    shadow = state.shadow_stage
+
+    assert shadow is not stage
+    assert shadow.GetRootLayer() is not stage.GetRootLayer()
+    assert shadow.GetSessionLayer() is not stage.GetSessionLayer()
 
     with ComposedChangeProjection(stage, [], state=state) as projection:
         assert projection.build_events() == []
         projection.commit()
 
-    assert state.baseline is baseline
+    assert state.shadow_stage is shadow
 
 
-def test_persistent_projection_sparse_commit_replaces_only_affected_prim():
+def test_persistent_projection_sparse_commit_advances_owned_shadow():
     stage = Usd.Stage.CreateInMemory()
     changed = stage.DefinePrim("/World/Changed", "Sphere")
     untouched = stage.DefinePrim("/World/Untouched", "Sphere")
     changed.GetAttribute("radius").Set(1.0)
     untouched.GetAttribute("radius").Set(3.0)
     state = ComposedProjectionState(stage)
-    changed_before = state.baseline.prims["/World/Changed"]
-    untouched_before = state.baseline.prims["/World/Untouched"]
+    shadow = state.shadow_stage
+    assert shadow.GetPrimAtPath("/World/Changed").GetAttribute("radius").Get() == 1.0
+    assert shadow.GetPrimAtPath("/World/Untouched").GetAttribute("radius").Get() == 3.0
 
     with ComposedChangeProjection(stage, [], state=state) as projection:
         changed.GetAttribute("radius").Set(2.0)
         assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
         projection.commit()
 
-    assert state.baseline.prims["/World/Changed"] is not changed_before
-    assert state.baseline.prims["/World/Untouched"] is untouched_before
+    assert state.shadow_stage is shadow
+    assert shadow.GetPrimAtPath("/World/Changed").GetAttribute("radius").Get() == 2.0
+    assert shadow.GetPrimAtPath("/World/Untouched").GetAttribute("radius").Get() == 3.0
+
+
+def test_owned_shadow_clones_and_advances_local_sublayers():
+    root = Sdf.Layer.CreateAnonymous("owned-shadow-root.usda")
+    sublayer = Sdf.Layer.CreateAnonymous("owned-shadow-edit.usda")
+    root.subLayerPaths.append(sublayer.identifier)
+    stage = Usd.Stage.Open(root)
+    with Usd.EditContext(stage, Usd.EditTarget(sublayer)):
+        stage.DefinePrim("/World/Thing", "Sphere").GetAttribute("radius").Set(1.0)
+    state = ComposedProjectionState(stage)
+    shadow = state.shadow_stage
+
+    assert sublayer.identifier not in shadow.GetRootLayer().subLayerPaths
+    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
+
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        with Usd.EditContext(stage, Usd.EditTarget(sublayer)):
+            stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Set(2.0)
+        assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
+        assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
+        projection.commit()
+
+    assert state.shadow_stage is shadow
+    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
+
+
+def test_owned_shadow_rebuilds_after_local_sublayer_topology_change():
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim("/World", "Xform")
+    state = ComposedProjectionState(stage)
+    old_shadow = state.shadow_stage
+
+    added = Sdf.Layer.CreateAnonymous("owned-shadow-added.usda")
+    added_stage = Usd.Stage.Open(added)
+    added_stage.DefinePrim("/World/Added", "Sphere")
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        stage.GetRootLayer().subLayerPaths.append(added.identifier)
+        projected = projection.build_events()
+        assert any(
+            item["k"] == "ensure_prim" and item["prim"] == "/World/Added"
+            for item in projected
+        )
+        assert not old_shadow.GetPrimAtPath("/World/Added")
+        projection.commit()
+
+    assert state.shadow_stage is not old_shadow
+    assert state.shadow_stage.GetPrimAtPath("/World/Added")
+
+
+def test_owned_shadow_flattens_package_root_and_preserves_resolved_assets(tmp_path):
+    texture = tmp_path / "texture.txt"
+    texture.write_text("asset", encoding="utf-8")
+    source_path = tmp_path / "source.usda"
+    source = Sdf.Layer.CreateNew(str(source_path))
+    source_stage = Usd.Stage.Open(source)
+    sphere = source_stage.DefinePrim("/World/Thing", "Sphere")
+    sphere.GetAttribute("radius").Set(1.0)
+    sphere.CreateAttribute("userProperties:asset", Sdf.ValueTypeNames.Asset).Set(
+        Sdf.AssetPath("texture.txt")
+    )
+    source.Save()
+
+    package_path = tmp_path / "scene.usdz"
+    assert UsdUtils.CreateNewUsdzPackage(
+        Sdf.AssetPath(str(source_path)),
+        str(package_path),
+    )
+    stage = Usd.Stage.Open(str(package_path))
+    state = ComposedProjectionState(stage)
+    shadow = state.shadow_stage
+    live_asset = stage.GetAttributeAtPath("/World/Thing.userProperties:asset").Get()
+    shadow_asset = shadow.GetAttributeAtPath("/World/Thing.userProperties:asset").Get()
+
+    assert shadow.GetRootLayer() is not stage.GetRootLayer()
+    assert shadow_asset.resolvedPath == live_asset.resolvedPath
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        stage.SetEditTarget(stage.GetRootLayer())
+        stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Set(2.0)
+        assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
+        assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
+        projection.commit()
+
+    assert state.shadow_stage is shadow
+    assert state.shadow_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
+
+
+def test_owned_shadow_survives_context_dependent_resolver_refresh(tmp_path):
+    install_root = Path(pxr.__file__).resolve().parents[3]
+    plugin_info = (
+        install_root
+        / "share"
+        / "usd"
+        / "examples"
+        / "plugin"
+        / "usdResolverExample"
+        / "resources"
+        / "plugInfo.json"
+    )
+    if not plugin_info.is_file():
+        pytest.skip("OpenUSD resolver example plugin is not installed")
+
+    script = textwrap.dedent(
+        r"""
+        import json
+        import sys
+        from pathlib import Path
+
+        from pxr import Ar, Plug, Sdf, Usd
+
+        from openusdconnect.composed_projection import (
+            ComposedChangeProjection,
+            ComposedProjectionState,
+        )
+
+
+        def write_asset(path, radius):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            layer = Sdf.Layer.CreateNew(str(path))
+            stage = Usd.Stage.Open(layer)
+            stage.DefinePrim("/Model", "Xform")
+            stage.DefinePrim("/Model/Geom", "Sphere").GetAttribute("radius").Set(radius)
+            layer.Save()
+
+
+        plugin_info = Path(sys.argv[1])
+        work = Path(sys.argv[2])
+        assert Plug.Registry().RegisterPlugins(str(plugin_info))
+        write_asset(work / "assets" / "Model" / "v1" / "model.usda", 1.0)
+        write_asset(work / "assets" / "Model" / "v2" / "model.usda", 2.0)
+        mapping = work / "versions.json"
+        mapping.write_text(json.dumps({"Model": "v1"}), encoding="utf-8")
+
+        resolver = Ar.GetResolver()
+        context = resolver.CreateContextFromString("asset", str(mapping))
+        root = Sdf.Layer.CreateNew(str(work / "root.usda"))
+        stage = Usd.Stage.Open(root, context)
+        stage.DefinePrim("/World", "Xform").GetReferences().AddReference(
+            "asset:Model/{$VERSION}/model.usda",
+            "/Model",
+        )
+        root.Save()
+
+        state = ComposedProjectionState(stage)
+        shadow = state.shadow_stage
+        assert shadow.GetAttributeAtPath("/World/Geom.radius").Get() == 1.0
+
+        mapping.write_text(json.dumps({"Model": "v2"}), encoding="utf-8")
+        resolver.RefreshContext(context)
+        assert stage.GetAttributeAtPath("/World/Geom.radius").Get() == 2.0
+        assert shadow.GetAttributeAtPath("/World/Geom.radius").Get() == 1.0
+        assert state.needs_full_reconcile
+
+        with ComposedChangeProjection(stage, [], state=state) as projection:
+            projected = projection.build_events()
+            assert any(
+                event["k"] == "set_reference"
+                and event["refs"][0]["asset_path"] == "asset:Model/v2/model.usda"
+                for event in projected
+            )
+            assert any(
+                event["k"] == "set_gprim_attrs"
+                and event["prim"] == "/World/Geom"
+                and event["attrs"]["radius"] == 2.0
+                for event in projected
+            )
+            projection.commit()
+
+        assert shadow.GetAttributeAtPath("/World/Geom.radius").Get() == 2.0
+        assert not state.needs_full_reconcile
+        with ComposedChangeProjection(stage, [], state=state) as projection:
+            assert projection.build_events() == []
+            projection.commit()
+        state.close()
+        """
+    )
+    env = os.environ.copy()
+    env["USD_RESOLVER_EXAMPLE_ASSET_DIR"] = str(tmp_path / "assets")
+    subprocess.run(
+        [sys.executable, "-c", script, str(plugin_info), str(tmp_path)],
+        check=True,
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        timeout=30,
+    )
+
+
+def test_owned_file_shadow_preserves_payload_load_rules(tmp_path):
+    payload_path = tmp_path / "payload.usda"
+    payload = Sdf.Layer.CreateNew(str(payload_path))
+    payload_stage = Usd.Stage.Open(payload)
+    payload_stage.DefinePrim("/Payload", "Xform")
+    payload_stage.DefinePrim("/Payload/Child", "Sphere")
+    payload.Save()
+
+    root_path = tmp_path / "root.usda"
+    root = Sdf.Layer.CreateNew(str(root_path))
+    root_stage = Usd.Stage.Open(root)
+    root_stage.DefinePrim("/World", "Xform").GetPayloads().AddPayload(
+        "payload.usda",
+        "/Payload",
+    )
+    root.Save()
+
+    stage = Usd.Stage.Open(str(root_path), Usd.Stage.LoadNone)
+    stage.Load("/World")
+    state = ComposedProjectionState(stage)
+
+    assert stage.GetPrimAtPath("/World/Child")
+    assert state.shadow_stage.GetPrimAtPath("/World/Child")
+
+
+def test_owned_file_shadow_incrementally_tracks_composed_masking(tmp_path):
+    weak_path = tmp_path / "weak.usda"
+    weak = Sdf.Layer.CreateNew(str(weak_path))
+    weak_stage = Usd.Stage.Open(weak)
+    weak_stage.DefinePrim("/World/Thing", "Sphere").GetAttribute("radius").Set(1.0)
+    weak.Save()
+
+    root_path = tmp_path / "root.usda"
+    root = Sdf.Layer.CreateNew(str(root_path))
+    root.subLayerPaths.append("weak.usda")
+    root_stage = Usd.Stage.Open(root)
+    root_stage.OverridePrim("/World/Thing").GetAttribute("radius").Set(2.0)
+    root.Save()
+
+    stage = Usd.Stage.Open(str(root_path))
+    state = ComposedProjectionState(stage)
+    shadow = state.shadow_stage
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        with Usd.EditContext(stage, Usd.EditTarget(weak)):
+            stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Set(3.0)
+        assert projection.build_events() == []
+        projection.commit()
+
+    assert state.shadow_stage is shadow
+    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        with Usd.EditContext(stage, Usd.EditTarget(root)):
+            stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Clear()
+        projected = projection.build_events()
+        assert any(
+            item["k"] == "set_gprim_attrs"
+            and item["attrs"]["radius"] == pytest.approx(3.0)
+            for item in projected
+        )
+        projection.commit()
+
+    assert state.shadow_stage is shadow
+    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 3.0
+
+
+def test_owned_file_shadow_incrementally_tracks_composition_arcs(tmp_path):
+    root_path = tmp_path / "root.usda"
+    root = Sdf.Layer.CreateNew(str(root_path))
+    root_stage = Usd.Stage.Open(root)
+    root_stage.CreateClassPrim("/Class")
+    root_stage.DefinePrim("/Class/Child", "Sphere").GetAttribute("radius").Set(4.0)
+    root_stage.DefinePrim("/World", "Xform")
+    root.Save()
+
+    stage = Usd.Stage.Open(str(root_path))
+    state = ComposedProjectionState(stage)
+    shadow = state.shadow_stage
+    assert not shadow.GetPrimAtPath("/World/Child")
+
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        stage.GetPrimAtPath("/World").GetInherits().AddInherit("/Class")
+        projected = projection.build_events()
+        assert any(
+            item["k"] == "ensure_prim" and item["prim"] == "/World/Child"
+            for item in projected
+        )
+        projection.commit()
+
+    assert state.shadow_stage is shadow
+    shadow_child = shadow.GetPrimAtPath("/World/Child")
+    assert shadow_child
+    assert shadow_child.GetAttribute("radius").Get() == pytest.approx(4.0)
+
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        stage.GetPrimAtPath("/World").GetInherits().ClearInherits()
+        projected = projection.build_events()
+        assert any(
+            item["k"] == "delete_prim" and item["prim"] == "/World/Child"
+            for item in projected
+        )
+        projection.commit()
+
+    assert state.shadow_stage is shadow
+    assert not shadow.GetPrimAtPath("/World/Child")
 
 
 def test_shadow_projection_state_noop_bind_preserves_shadow_mode():
@@ -301,8 +604,6 @@ def test_shadow_projection_state_noop_bind_preserves_shadow_mode():
     state.bind(live)
 
     assert state.shadow_stage is shadow
-    with pytest.raises(RuntimeError, match="shadow mode"):
-        state.baseline.ensure("/World")
 
 
 def test_layered_shadow_advances_only_after_native_adapter_success():

--- a/tests/unit/test_composed_projection.py
+++ b/tests/unit/test_composed_projection.py
@@ -264,75 +264,75 @@ def test_persistent_projection_state_reconciles_after_adapter_failure():
         settled.commit()
 
 
-def test_persistent_projection_noop_commit_keeps_owned_shadow_stage():
+def test_noop_commit_keeps_owned_previous_stage():
     stage = Usd.Stage.CreateInMemory()
     stage.DefinePrim("/World/Thing", "Sphere")
     state = ComposedProjectionState(stage)
-    shadow = state.shadow_stage
+    previous_stage = state.previous_stage
 
-    assert shadow is not stage
-    assert shadow.GetRootLayer() is not stage.GetRootLayer()
-    assert shadow.GetSessionLayer() is not stage.GetSessionLayer()
+    assert previous_stage is not stage
+    assert previous_stage.GetRootLayer() is not stage.GetRootLayer()
+    assert previous_stage.GetSessionLayer() is not stage.GetSessionLayer()
 
     with ComposedChangeProjection(stage, [], state=state) as projection:
         assert projection.build_events() == []
         projection.commit()
 
-    assert state.shadow_stage is shadow
+    assert state.previous_stage is previous_stage
 
 
-def test_persistent_projection_sparse_commit_advances_owned_shadow():
+def test_sparse_commit_advances_owned_previous_stage():
     stage = Usd.Stage.CreateInMemory()
     changed = stage.DefinePrim("/World/Changed", "Sphere")
     untouched = stage.DefinePrim("/World/Untouched", "Sphere")
     changed.GetAttribute("radius").Set(1.0)
     untouched.GetAttribute("radius").Set(3.0)
     state = ComposedProjectionState(stage)
-    shadow = state.shadow_stage
-    assert shadow.GetPrimAtPath("/World/Changed").GetAttribute("radius").Get() == 1.0
-    assert shadow.GetPrimAtPath("/World/Untouched").GetAttribute("radius").Get() == 3.0
+    previous_stage = state.previous_stage
+    assert previous_stage.GetPrimAtPath("/World/Changed").GetAttribute("radius").Get() == 1.0
+    assert previous_stage.GetPrimAtPath("/World/Untouched").GetAttribute("radius").Get() == 3.0
 
     with ComposedChangeProjection(stage, [], state=state) as projection:
         changed.GetAttribute("radius").Set(2.0)
         assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
         projection.commit()
 
-    assert state.shadow_stage is shadow
-    assert shadow.GetPrimAtPath("/World/Changed").GetAttribute("radius").Get() == 2.0
-    assert shadow.GetPrimAtPath("/World/Untouched").GetAttribute("radius").Get() == 3.0
+    assert state.previous_stage is previous_stage
+    assert previous_stage.GetPrimAtPath("/World/Changed").GetAttribute("radius").Get() == 2.0
+    assert previous_stage.GetPrimAtPath("/World/Untouched").GetAttribute("radius").Get() == 3.0
 
 
-def test_owned_shadow_clones_and_advances_local_sublayers():
-    root = Sdf.Layer.CreateAnonymous("owned-shadow-root.usda")
-    sublayer = Sdf.Layer.CreateAnonymous("owned-shadow-edit.usda")
+def test_owned_previous_stage_clones_and_advances_local_sublayers():
+    root = Sdf.Layer.CreateAnonymous("previous-state-root.usda")
+    sublayer = Sdf.Layer.CreateAnonymous("previous-state-edit.usda")
     root.subLayerPaths.append(sublayer.identifier)
     stage = Usd.Stage.Open(root)
     with Usd.EditContext(stage, Usd.EditTarget(sublayer)):
         stage.DefinePrim("/World/Thing", "Sphere").GetAttribute("radius").Set(1.0)
     state = ComposedProjectionState(stage)
-    shadow = state.shadow_stage
+    previous_stage = state.previous_stage
 
-    assert sublayer.identifier not in shadow.GetRootLayer().subLayerPaths
-    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
+    assert sublayer.identifier not in previous_stage.GetRootLayer().subLayerPaths
+    assert previous_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
 
     with ComposedChangeProjection(stage, [], state=state) as projection:
         with Usd.EditContext(stage, Usd.EditTarget(sublayer)):
             stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Set(2.0)
-        assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
+        assert previous_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
         assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
         projection.commit()
 
-    assert state.shadow_stage is shadow
-    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
+    assert state.previous_stage is previous_stage
+    assert previous_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
 
 
-def test_owned_shadow_rebuilds_after_local_sublayer_topology_change():
+def test_owned_previous_stage_rebuilds_after_local_sublayer_topology_change():
     stage = Usd.Stage.CreateInMemory()
     stage.DefinePrim("/World", "Xform")
     state = ComposedProjectionState(stage)
-    old_shadow = state.shadow_stage
+    old_previous_stage = state.previous_stage
 
-    added = Sdf.Layer.CreateAnonymous("owned-shadow-added.usda")
+    added = Sdf.Layer.CreateAnonymous("previous-state-added.usda")
     added_stage = Usd.Stage.Open(added)
     added_stage.DefinePrim("/World/Added", "Sphere")
     with ComposedChangeProjection(stage, [], state=state) as projection:
@@ -342,14 +342,14 @@ def test_owned_shadow_rebuilds_after_local_sublayer_topology_change():
             item["k"] == "ensure_prim" and item["prim"] == "/World/Added"
             for item in projected
         )
-        assert not old_shadow.GetPrimAtPath("/World/Added")
+        assert not old_previous_stage.GetPrimAtPath("/World/Added")
         projection.commit()
 
-    assert state.shadow_stage is not old_shadow
-    assert state.shadow_stage.GetPrimAtPath("/World/Added")
+    assert state.previous_stage is not old_previous_stage
+    assert state.previous_stage.GetPrimAtPath("/World/Added")
 
 
-def test_owned_shadow_flattens_package_root_and_preserves_resolved_assets(tmp_path):
+def test_owned_previous_stage_consolidates_package_and_preserves_assets(tmp_path):
     texture = tmp_path / "texture.txt"
     texture.write_text("asset", encoding="utf-8")
     source_path = tmp_path / "source.usda"
@@ -369,24 +369,24 @@ def test_owned_shadow_flattens_package_root_and_preserves_resolved_assets(tmp_pa
     )
     stage = Usd.Stage.Open(str(package_path))
     state = ComposedProjectionState(stage)
-    shadow = state.shadow_stage
+    previous_stage = state.previous_stage
     live_asset = stage.GetAttributeAtPath("/World/Thing.userProperties:asset").Get()
-    shadow_asset = shadow.GetAttributeAtPath("/World/Thing.userProperties:asset").Get()
+    previous_asset = previous_stage.GetAttributeAtPath("/World/Thing.userProperties:asset").Get()
 
-    assert shadow.GetRootLayer() is not stage.GetRootLayer()
-    assert shadow_asset.resolvedPath == live_asset.resolvedPath
+    assert previous_stage.GetRootLayer() is not stage.GetRootLayer()
+    assert previous_asset.resolvedPath == live_asset.resolvedPath
     with ComposedChangeProjection(stage, [], state=state) as projection:
         stage.SetEditTarget(stage.GetRootLayer())
         stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Set(2.0)
-        assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
+        assert previous_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 1.0
         assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
         projection.commit()
 
-    assert state.shadow_stage is shadow
-    assert state.shadow_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
+    assert state.previous_stage is previous_stage
+    assert state.previous_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
 
 
-def test_owned_shadow_survives_context_dependent_resolver_refresh(tmp_path):
+def test_owned_previous_stage_survives_context_dependent_resolver_refresh(tmp_path):
     install_root = Path(pxr.__file__).resolve().parents[3]
     plugin_info = (
         install_root
@@ -443,13 +443,13 @@ def test_owned_shadow_survives_context_dependent_resolver_refresh(tmp_path):
         root.Save()
 
         state = ComposedProjectionState(stage)
-        shadow = state.shadow_stage
-        assert shadow.GetAttributeAtPath("/World/Geom.radius").Get() == 1.0
+        previous_stage = state.previous_stage
+        assert previous_stage.GetAttributeAtPath("/World/Geom.radius").Get() == 1.0
 
         mapping.write_text(json.dumps({"Model": "v2"}), encoding="utf-8")
         resolver.RefreshContext(context)
         assert stage.GetAttributeAtPath("/World/Geom.radius").Get() == 2.0
-        assert shadow.GetAttributeAtPath("/World/Geom.radius").Get() == 1.0
+        assert previous_stage.GetAttributeAtPath("/World/Geom.radius").Get() == 1.0
         assert state.needs_full_reconcile
 
         with ComposedChangeProjection(stage, [], state=state) as projection:
@@ -467,7 +467,7 @@ def test_owned_shadow_survives_context_dependent_resolver_refresh(tmp_path):
             )
             projection.commit()
 
-        assert shadow.GetAttributeAtPath("/World/Geom.radius").Get() == 2.0
+        assert previous_stage.GetAttributeAtPath("/World/Geom.radius").Get() == 2.0
         assert not state.needs_full_reconcile
         with ComposedChangeProjection(stage, [], state=state) as projection:
             assert projection.build_events() == []
@@ -486,7 +486,7 @@ def test_owned_shadow_survives_context_dependent_resolver_refresh(tmp_path):
     )
 
 
-def test_owned_file_shadow_preserves_payload_load_rules(tmp_path):
+def test_owned_previous_stage_preserves_payload_load_rules(tmp_path):
     payload_path = tmp_path / "payload.usda"
     payload = Sdf.Layer.CreateNew(str(payload_path))
     payload_stage = Usd.Stage.Open(payload)
@@ -508,10 +508,10 @@ def test_owned_file_shadow_preserves_payload_load_rules(tmp_path):
     state = ComposedProjectionState(stage)
 
     assert stage.GetPrimAtPath("/World/Child")
-    assert state.shadow_stage.GetPrimAtPath("/World/Child")
+    assert state.previous_stage.GetPrimAtPath("/World/Child")
 
 
-def test_owned_file_shadow_incrementally_tracks_composed_masking(tmp_path):
+def test_owned_previous_stage_incrementally_tracks_composed_masking(tmp_path):
     weak_path = tmp_path / "weak.usda"
     weak = Sdf.Layer.CreateNew(str(weak_path))
     weak_stage = Usd.Stage.Open(weak)
@@ -527,15 +527,15 @@ def test_owned_file_shadow_incrementally_tracks_composed_masking(tmp_path):
 
     stage = Usd.Stage.Open(str(root_path))
     state = ComposedProjectionState(stage)
-    shadow = state.shadow_stage
+    previous_stage = state.previous_stage
     with ComposedChangeProjection(stage, [], state=state) as projection:
         with Usd.EditContext(stage, Usd.EditTarget(weak)):
             stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Set(3.0)
         assert projection.build_events() == []
         projection.commit()
 
-    assert state.shadow_stage is shadow
-    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
+    assert state.previous_stage is previous_stage
+    assert previous_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 2.0
     with ComposedChangeProjection(stage, [], state=state) as projection:
         with Usd.EditContext(stage, Usd.EditTarget(root)):
             stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Clear()
@@ -547,11 +547,11 @@ def test_owned_file_shadow_incrementally_tracks_composed_masking(tmp_path):
         )
         projection.commit()
 
-    assert state.shadow_stage is shadow
-    assert shadow.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 3.0
+    assert state.previous_stage is previous_stage
+    assert previous_stage.GetPrimAtPath("/World/Thing").GetAttribute("radius").Get() == 3.0
 
 
-def test_owned_file_shadow_incrementally_tracks_composition_arcs(tmp_path):
+def test_owned_previous_stage_incrementally_tracks_composition_arcs(tmp_path):
     root_path = tmp_path / "root.usda"
     root = Sdf.Layer.CreateNew(str(root_path))
     root_stage = Usd.Stage.Open(root)
@@ -562,8 +562,8 @@ def test_owned_file_shadow_incrementally_tracks_composition_arcs(tmp_path):
 
     stage = Usd.Stage.Open(str(root_path))
     state = ComposedProjectionState(stage)
-    shadow = state.shadow_stage
-    assert not shadow.GetPrimAtPath("/World/Child")
+    previous_stage = state.previous_stage
+    assert not previous_stage.GetPrimAtPath("/World/Child")
 
     with ComposedChangeProjection(stage, [], state=state) as projection:
         stage.GetPrimAtPath("/World").GetInherits().AddInherit("/Class")
@@ -574,10 +574,10 @@ def test_owned_file_shadow_incrementally_tracks_composition_arcs(tmp_path):
         )
         projection.commit()
 
-    assert state.shadow_stage is shadow
-    shadow_child = shadow.GetPrimAtPath("/World/Child")
-    assert shadow_child
-    assert shadow_child.GetAttribute("radius").Get() == pytest.approx(4.0)
+    assert state.previous_stage is previous_stage
+    previous_child = previous_stage.GetPrimAtPath("/World/Child")
+    assert previous_child
+    assert previous_child.GetAttribute("radius").Get() == pytest.approx(4.0)
 
     with ComposedChangeProjection(stage, [], state=state) as projection:
         stage.GetPrimAtPath("/World").GetInherits().ClearInherits()
@@ -588,25 +588,25 @@ def test_owned_file_shadow_incrementally_tracks_composition_arcs(tmp_path):
         )
         projection.commit()
 
-    assert state.shadow_stage is shadow
-    assert not shadow.GetPrimAtPath("/World/Child")
+    assert state.previous_stage is previous_stage
+    assert not previous_stage.GetPrimAtPath("/World/Child")
 
 
-def test_shadow_projection_state_noop_bind_preserves_shadow_mode():
+def test_external_previous_stage_survives_noop_bind():
     live = Usd.Stage.CreateInMemory()
-    shadow = Usd.Stage.CreateInMemory()
+    previous = Usd.Stage.CreateInMemory()
     state = ComposedProjectionState(
         live,
-        shadow_stage=shadow,
-        advance_shadow=lambda: None,
+        previous_stage=previous,
+        advance_previous_stage=lambda: None,
     )
 
     state.bind(live)
 
-    assert state.shadow_stage is shadow
+    assert state.previous_stage is previous
 
 
-def test_layered_shadow_advances_only_after_native_adapter_success():
+def test_layered_previous_stage_advances_only_after_native_adapter_success():
     class FailingOnceAdapter(MockAdapter):
         fail_next = False
 
@@ -631,7 +631,7 @@ def test_layered_shadow_advances_only_after_native_adapter_success():
     adapter = FailingOnceAdapter()
     dispatcher = EventDispatcher(receiver=receiver, adapter=adapter, mirror_stage=stage)
     assert dispatcher.drain_and_apply() > 0
-    assert dispatcher._projection_state.shadow_stage is not stage
+    assert dispatcher._projection_state.previous_stage is not stage
 
     adapter.fail_next = True
     receiver.messages = [
@@ -651,9 +651,9 @@ def test_layered_shadow_advances_only_after_native_adapter_success():
 
     state = dispatcher._projection_state
     assert state.needs_full_reconcile
-    shadow_prim = state.shadow_stage.GetPrimAtPath("/World/Thing")
-    shadow_matrix = UsdGeom.Xformable(shadow_prim).GetLocalTransformation()
-    assert tuple(shadow_matrix.ExtractTranslation()) == pytest.approx((1.0, 0.0, 0.0))
+    previous_prim = state.previous_stage.GetPrimAtPath("/World/Thing")
+    previous_matrix = UsdGeom.Xformable(previous_prim).GetLocalTransformation()
+    assert tuple(previous_matrix.ExtractTranslation()) == pytest.approx((1.0, 0.0, 0.0))
 
     receiver.messages = [
         encode_message(
@@ -666,10 +666,10 @@ def test_layered_shadow_advances_only_after_native_adapter_success():
     assert dispatcher.drain_and_apply() > 0
     assert adapter.get_trs("/World/Thing")["t"] == pytest.approx([2.0, 0.0, 0.0])
     assert not state.needs_full_reconcile
-    shadow_matrix = UsdGeom.Xformable(
-        state.shadow_stage.GetPrimAtPath("/World/Thing")
+    previous_matrix = UsdGeom.Xformable(
+        state.previous_stage.GetPrimAtPath("/World/Thing")
     ).GetLocalTransformation()
-    assert tuple(shadow_matrix.ExtractTranslation()) == pytest.approx((2.0, 0.0, 0.0))
+    assert tuple(previous_matrix.ExtractTranslation()) == pytest.approx((2.0, 0.0, 0.0))
 
 
 def test_unknown_event_kind_cannot_bypass_native_projection():

--- a/tests/unit/test_composed_projection.py
+++ b/tests/unit/test_composed_projection.py
@@ -7,8 +7,13 @@ from pxr import Sdf, Usd, UsdShade
 
 from openusdconnect.adapters import MockAdapter
 from openusdconnect.codec import encode_message
-from openusdconnect.composed_projection import ComposedChangeProjection
+from openusdconnect.composed_projection import (
+    ComposedChangeProjection,
+    ComposedProjectionState,
+)
 from openusdconnect.dispatcher import EventDispatcher
+from openusdconnect.event_apply import apply_events
+from openusdconnect.sdf_spec_delta import serialize_spec_fields
 
 from .layered_replay_test_support import (
     _BASE_LAYER,
@@ -22,6 +27,266 @@ from .layered_replay_test_support import (
     _state,
     _xform_events,
 )
+
+
+def _exact_spec_event(
+    layer: Sdf.Layer,
+    spec_path: str,
+    spec_kind: str,
+    fields: list[str],
+) -> dict:
+    return {
+        "k": "set_sdf_spec_fields",
+        "prim": "/" if spec_kind == "layer" else spec_path,
+        "spec_path": spec_path,
+        "spec_kind": spec_kind,
+        "fields": fields,
+        "fragment": serialize_spec_fields(
+            layer,
+            spec_path,
+            spec_kind,
+            fields,
+            stabilize_asset_paths=False,
+        ),
+        "removed": False,
+    }
+
+
+@pytest.mark.parametrize("field", ["inheritPaths", "specializes"])
+def test_class_arc_field_projects_new_composed_subtree(field):
+    stage = Usd.Stage.CreateInMemory()
+    stage.CreateClassPrim("/Class")
+    child = stage.DefinePrim("/Class/Child", "Sphere")
+    child.GetAttribute("radius").Set(4.0)
+    stage.DefinePrim("/World", "Xform")
+
+    incoming = Sdf.Layer.CreateAnonymous("class-arc.usda")
+    incoming.TransferContent(stage.GetRootLayer())
+    incoming_stage = Usd.Stage.Open(incoming)
+    world = incoming_stage.GetPrimAtPath("/World")
+    if field == "inheritPaths":
+        world.GetInherits().AddInherit("/Class")
+    else:
+        world.GetSpecializes().AddSpecialize("/Class")
+    event = _exact_spec_event(incoming, "/World", "prim", [field])
+
+    projection = ComposedChangeProjection(stage, [event])
+    apply_events(stage, [event])
+    projected = projection.build_events()
+
+    assert stage.GetPrimAtPath("/World/Child")
+    assert any(item["k"] == "ensure_prim" and item["prim"] == "/World/Child" for item in projected)
+    assert any(
+        item["k"] == "set_gprim_attrs"
+        and item["prim"] == "/World/Child"
+        and item["attrs"]["radius"] == pytest.approx(4.0)
+        for item in projected
+    )
+    adapter = MockAdapter()
+    adapter.apply_events(projected)
+    assert adapter.get_prim("/World/Child")["gprim_attrs"]["radius"] == pytest.approx(4.0)
+
+    cleared = Sdf.Layer.CreateAnonymous("class-arc-cleared.usda")
+    cleared.TransferContent(stage.GetRootLayer())
+    cleared_stage = Usd.Stage.Open(cleared)
+    cleared_world = cleared_stage.GetPrimAtPath("/World")
+    if field == "inheritPaths":
+        cleared_world.GetInherits().ClearInherits()
+    else:
+        cleared_world.GetSpecializes().ClearSpecializes()
+    clear_event = _exact_spec_event(cleared, "/World", "prim", [field])
+
+    clear_projection = ComposedChangeProjection(stage, [clear_event])
+    apply_events(stage, [clear_event])
+    clear_projected = clear_projection.build_events()
+
+    assert not stage.GetPrimAtPath("/World/Child")
+    assert any(
+        item["k"] == "delete_prim" and item["prim"] == "/World/Child" for item in clear_projected
+    )
+    adapter.apply_events(clear_projected)
+    assert adapter.get_prim("/World/Child") == {}
+
+
+def test_layer_relocates_projects_old_and_new_composed_subtrees():
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim("/Ref", "Xform")
+    child = stage.DefinePrim("/Ref/Child", "Sphere")
+    child.GetAttribute("radius").Set(5.0)
+    stage.DefinePrim("/World", "Xform").GetReferences().AddInternalReference("/Ref")
+    assert stage.GetPrimAtPath("/World/Child")
+
+    incoming = Sdf.Layer.CreateAnonymous("relocates.usda")
+    incoming.TransferContent(stage.GetRootLayer())
+    incoming.relocates = [
+        (Sdf.Path("/World/Child"), Sdf.Path("/World/Moved")),
+    ]
+    event = _exact_spec_event(incoming, "/", "layer", ["layerRelocates"])
+
+    projection = ComposedChangeProjection(stage, [event])
+    apply_events(stage, [event])
+    projected = projection.build_events()
+
+    assert not stage.GetPrimAtPath("/World/Child")
+    assert stage.GetPrimAtPath("/World/Moved")
+    assert any(item["k"] == "delete_prim" and item["prim"] == "/World/Child" for item in projected)
+    assert any(item["k"] == "ensure_prim" and item["prim"] == "/World/Moved" for item in projected)
+    assert any(
+        item["k"] == "set_gprim_attrs"
+        and item["prim"] == "/World/Moved"
+        and item["attrs"]["radius"] == pytest.approx(5.0)
+        for item in projected
+    )
+    adapter = MockAdapter()
+    adapter.ensure_prim("/World/Child", "Sphere")
+    adapter.set_gprim_attrs("/World/Child", {"radius": 5.0})
+    adapter.apply_events(projected)
+    assert adapter.get_prim("/World/Child") == {}
+    assert adapter.get_prim("/World/Moved")["gprim_attrs"]["radius"] == pytest.approx(5.0)
+
+    cleared = Sdf.Layer.CreateAnonymous("relocates-cleared.usda")
+    cleared.TransferContent(stage.GetRootLayer())
+    cleared.relocates = []
+    clear_event = _exact_spec_event(cleared, "/", "layer", ["layerRelocates"])
+
+    clear_projection = ComposedChangeProjection(stage, [clear_event])
+    apply_events(stage, [clear_event])
+    clear_projected = clear_projection.build_events()
+
+    assert stage.GetPrimAtPath("/World/Child")
+    assert not stage.GetPrimAtPath("/World/Moved")
+    assert any(
+        item["k"] == "ensure_prim" and item["prim"] == "/World/Child" for item in clear_projected
+    )
+    assert any(
+        item["k"] == "delete_prim" and item["prim"] == "/World/Moved" for item in clear_projected
+    )
+    adapter.apply_events(clear_projected)
+    assert adapter.get_prim("/World/Moved") == {}
+    assert adapter.get_prim("/World/Child")["gprim_attrs"]["radius"] == pytest.approx(5.0)
+
+
+@pytest.mark.parametrize("field", ["inheritPaths", "specializes"])
+def test_class_arc_notice_projects_implied_consumer_without_class_artifacts(field):
+    stage = Usd.Stage.CreateInMemory()
+    stage.CreateClassPrim("/Class")
+    child = stage.DefinePrim("/Class/Child", "Sphere")
+    child.GetAttribute("radius").Set(6.0)
+    intermediate = stage.CreateClassPrim("/Intermediate")
+    world = stage.DefinePrim("/World", "Xform")
+    if field == "inheritPaths":
+        world.GetInherits().AddInherit(intermediate.GetPath())
+    else:
+        world.GetSpecializes().AddSpecialize(intermediate.GetPath())
+    assert not stage.GetPrimAtPath("/World/Child")
+
+    incoming = Sdf.Layer.CreateAnonymous("implied-class-arc.usda")
+    incoming.TransferContent(stage.GetRootLayer())
+    incoming_stage = Usd.Stage.Open(incoming)
+    incoming_intermediate = incoming_stage.GetPrimAtPath("/Intermediate")
+    if field == "inheritPaths":
+        incoming_intermediate.GetInherits().AddInherit("/Class")
+    else:
+        incoming_intermediate.GetSpecializes().AddSpecialize("/Class")
+    event = _exact_spec_event(incoming, "/Intermediate", "prim", [field])
+
+    projection = ComposedChangeProjection(stage, [event])
+    apply_events(stage, [event])
+    projected = projection.build_events()
+
+    assert stage.GetPrimAtPath("/World/Child")
+    assert any(item["k"] == "ensure_prim" and item["prim"] == "/World/Child" for item in projected)
+    assert any(
+        item["k"] == "set_gprim_attrs"
+        and item["prim"] == "/World/Child"
+        and item["attrs"]["radius"] == pytest.approx(6.0)
+        for item in projected
+    )
+    assert not any(
+        item.get("prim", "").startswith(("/Class", "/Intermediate")) for item in projected
+    )
+
+
+def test_whole_spec_removal_projects_delete_when_changed_fields_are_empty():
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim("/World/Thing", "Sphere")
+    event = {
+        "k": "set_sdf_spec_fields",
+        "prim": "/World/Thing",
+        "spec_path": "/World/Thing",
+        "spec_kind": "prim",
+        "fields": [],
+        "fragment": "",
+        "removed": True,
+    }
+
+    projection = ComposedChangeProjection(stage, [event])
+    apply_events(stage, [event])
+    projected = projection.build_events()
+
+    assert not stage.GetPrimAtPath("/World/Thing")
+    assert {item["prim"] for item in projected if item["k"] == "delete_prim"} == {"/World/Thing"}
+
+
+def test_persistent_projection_state_reconciles_after_adapter_failure():
+    stage = Usd.Stage.CreateInMemory()
+    sphere = stage.DefinePrim("/World/Thing", "Sphere")
+    sphere.GetAttribute("radius").Set(1.0)
+    state = ComposedProjectionState(stage)
+
+    with pytest.raises(RuntimeError, match="adapter failed"):
+        with ComposedChangeProjection(stage, [], state=state) as projection:
+            sphere.GetAttribute("radius").Set(2.0)
+            assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
+            raise RuntimeError("adapter failed")
+
+    assert state.needs_full_reconcile
+    with ComposedChangeProjection(stage, [], state=state) as recovery:
+        projected = recovery.build_events()
+        assert any(
+            item["k"] == "set_gprim_attrs"
+            and item["prim"] == "/World/Thing"
+            and item["attrs"]["radius"] == pytest.approx(2.0)
+            for item in projected
+        )
+        recovery.commit()
+
+    assert not state.needs_full_reconcile
+    with ComposedChangeProjection(stage, [], state=state) as settled:
+        assert settled.build_events() == []
+        settled.commit()
+
+
+def test_persistent_projection_noop_commit_keeps_baseline_object():
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim("/World/Thing", "Sphere")
+    state = ComposedProjectionState(stage)
+    baseline = state.baseline
+
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        assert projection.build_events() == []
+        projection.commit()
+
+    assert state.baseline is baseline
+
+
+def test_persistent_projection_sparse_commit_replaces_only_affected_prim():
+    stage = Usd.Stage.CreateInMemory()
+    changed = stage.DefinePrim("/World/Changed", "Sphere")
+    untouched = stage.DefinePrim("/World/Untouched", "Sphere")
+    changed.GetAttribute("radius").Set(1.0)
+    untouched.GetAttribute("radius").Set(3.0)
+    state = ComposedProjectionState(stage)
+    changed_before = state.baseline.prims["/World/Changed"]
+    untouched_before = state.baseline.prims["/World/Untouched"]
+
+    with ComposedChangeProjection(stage, [], state=state) as projection:
+        changed.GetAttribute("radius").Set(2.0)
+        assert any(item["k"] == "set_gprim_attrs" for item in projection.build_events())
+        projection.commit()
+
+    assert state.baseline.prims["/World/Changed"] is not changed_before
+    assert state.baseline.prims["/World/Untouched"] is untouched_before
 
 
 def test_unknown_event_kind_cannot_bypass_native_projection():


### PR DESCRIPTION
## Summary

Reworks receive-side composed projection for external/native DCC scenes so
incremental USD changes can be projected correctly without repeatedly capturing
large Python snapshots of composed stage state.

The dispatcher now maintains a separate USD previous-state stage representing
the last state successfully delivered to the adapter. Transactions compare that
stage with the live composed mirror, then advance the previous state only after
adapter delivery succeeds.

## What changed

- Replaced full Python projection snapshots with persistent USD previous-state
  stages.
- Collects and reads only transaction-relevant composed values.
- Preserves correctness across:
  - layer-strength masking, reordering, and muting;
  - references, payloads, variants, and inherited composition;
  - transforms, geometry, materials, connections, and point instancers;
  - type changes, renames, deletions, activation, visibility, and instancing;
  - adapter failures and subsequent full reconciliation.
- Advances managed collaboration layers incrementally after successful native
  delivery.
- Preserves resolver anchoring for independently owned previous-state stages
  using public OpenUSD APIs.
- Adds a benchmark utility for startup, no-op, sparse-update, and memory
  measurements.

## Adapter destination contract

`DCCAdapter.targets_stage()` now explicitly selects the layered receive path:

- Returning the exact mirror-stage instance applies events directly to USD and
  skips composed projection.
- Returning `None` selects projection into an external/native scene.
- Returning a different `Usd.Stage` also selects projection because it is a
  separate destination.

The comparison uses object identity. `UsdStageAdapter` implements the direct-USD
contract, while adapters for Blender or other native DCC scenes inherit the
default `None` result.

## Resolver-context refreshes

The low-cost layered previous-state stage shares the immutable base root layer
with the live stage. A live context-dependent resolver refresh can therefore
recompose both stages before the former topology can be observed.

Rather than imposing stage cloning and additional memory on every session, this
case now has an explicit recovery contract:

- log an actionable error;
- set `native_scene_rebuild_required`;
- raise `NativeSceneRebuildRequired` before draining additional input;
- preserve queued messages and sequence position;
- resume after dispatcher recreation, replacement-stage rebind with native
  reconstruction, restart, or explicit native-scene rebuild acknowledgement.

Owned resolver-isolated previous stages can still perform an ordinary full
reconcile.

## Performance

Local CarbonFrameBike measurements for the final implementation:

| Metric | Median |
|---|---:|
| Dispatcher/projection startup | ~3.20 ms |
| Sparse transaction | ~0.176 ms |
| Sparse p95 | ~0.192 ms |
| Rebuild safety check | ~43 ns |
| Empty queue drain | ~0.2 µs |

The normal path performs no per-transaction stage cloning or complete composed
stage scan.