### PR TITLE
Fix native import projection and Blender round-trip fidelity

### DIFF
--- a/integrations/blender/blender_adapter.py
+++ b/integrations/blender/blender_adapter.py
@@ -32,6 +32,12 @@ from openusdconnect.axis_conversion import (
     yup_to_zup_vec,
 )
 from openusdconnect.connectable_attrs import output_attr, split_qualified_attr
+from openusdconnect.protocol_constants import (
+    K_LOAD_PAYLOAD,
+    K_SET_REFERENCE,
+    K_SET_VARIANT_SELECTIONS,
+    K_UNLOAD_PAYLOAD,
+)
 from openusdconnect.shader_connections import resolve_nodegraph_connection
 
 from .shader_mapper import create_default_registry
@@ -40,6 +46,11 @@ from .shader_mapper import create_default_registry
 _PROP_USD_IMPORTED = "_usd_imported"
 # Additional USD prim paths Blender collapsed onto the same object.
 _PROP_USD_PRIM_ALIASES = "_usd_prim_path_aliases"
+# USD prim whose local transform is represented by this Blender object.
+# Blender can collapse a parent Xform and its typed child onto one object;
+# geometry/material edits still use ``usd_prim_path``, while reverse-captured
+# object transforms must be authored on the parent Xform.
+_PROP_USD_XFORM_PRIM_PATH = "_usd_xform_prim_path"
 
 
 def _object_prim_paths(obj) -> tuple[str, ...]:
@@ -1280,21 +1291,25 @@ class BlenderAdapter(DCCAdapter):
     def _find_material_for_shader(self, prim_path: str, create: bool = False):
         """Find the Blender material that owns a shader prim path.
 
-        Walks up the prim path checking the registry cache first (O(1)),
-        then falls back to usd_material_path tag scan, then name match.
+        ``prim_path`` may identify either a shader below a material or the
+        material itself (for an ``outputs:surface`` connection). Walks from
+        that exact path toward the root, checking the registry cache first
+        (O(1)), then falls back to usd_material_path tag scan and name match.
         """
-        # Walk up the shader path to find the material ancestor
+        # Check the exact path first: output-side connections are authored on
+        # the Material prim rather than on one of its descendant shaders.
         path = prim_path
-        while "/" in path:
-            path = path.rsplit("/", 1)[0]
-            # O(1) registry lookup
+        while path:
             mat = self._registry.find_material(path)
             if mat:
                 return mat
+            if "/" not in path:
+                break
+            path = path.rsplit("/", 1)[0]
         # Fallback: scan all materials by usd_material_path tag
         for m in bpy.data.materials:
             mp = m.get("usd_material_path", "")
-            if mp and prim_path.startswith(mp + "/"):
+            if mp and (prim_path == mp or prim_path.startswith(mp + "/")):
                 self._registry.register_material(mp, m)
                 return m
         # Fallback: walk up path and match by name
@@ -2032,6 +2047,26 @@ class BlenderAdapter(DCCAdapter):
     def has_imported_children(self, prim_path: str) -> bool:
         """Return True when a reference/payload prim has imported DCC children."""
         return self._ref_children_exist(prim_path)
+
+    def native_composition_subtree_roots(self, events: list[dict]) -> set[str]:
+        """Declare roots whose descendants Blender's USD importer realizes."""
+        roots = {
+            str(event["prim"])
+            for event in events
+            if event.get("prim")
+            and event.get("k") in {K_SET_REFERENCE, K_LOAD_PAYLOAD, K_UNLOAD_PAYLOAD}
+        }
+        roots.update(
+            str(event["prim"])
+            for event in events
+            if event.get("k") == K_SET_VARIANT_SELECTIONS
+            and event.get("prim")
+            and (
+                self.has_imported_children(str(event["prim"]))
+                or str(event["prim"]) in roots
+            )
+        )
+        return roots
 
     def _remove_imported_ref_children(self, prim_path: str):
         """Remove child objects previously imported for a reference prim (keep container)."""

--- a/integrations/blender/capture.py
+++ b/integrations/blender/capture.py
@@ -59,6 +59,46 @@ def _compute_local_trs(obj):
     return local_matrix.decompose()
 
 
+def _usd_xform_scale(obj, displayed_scale):
+    """Remove Blender-only primitive sizing from an object's display scale.
+
+    The adapter represents parametric USD geometry on Blender's unit meshes by
+    composing two independent USD quantities into ``Object.scale``::
+
+        displayed scale = primitive geometry scale * xformOp:scale
+
+    Reverse sync must invert that representation. Writing the displayed scale
+    directly to ``xformOp:scale`` makes every receive/emit round trip multiply
+    the primitive sizing again (a size-1 Cube halves on every cycle).
+    """
+    original = getattr(obj, "original", obj)
+    geometry_scale = original.get("usd_geom_scale", (1.0, 1.0, 1.0))
+    previous_xform_scale = original.get("usd_xform_scale", (1.0, 1.0, 1.0))
+    result = []
+    for displayed, geometry, previous in zip(
+        displayed_scale,
+        geometry_scale,
+        previous_xform_scale,
+        strict=True,
+    ):
+        geometry = float(geometry)
+        if abs(geometry) > 1e-12:
+            authored = float(displayed) / geometry
+            # Blender stores Object.scale as float32. Dividing that rounded
+            # display value by the geometry contribution can otherwise move
+            # the independent USD scale by a few ulps on every user update.
+            tolerance = 1e-6 * max(1.0, abs(float(previous)))
+            if abs(authored - float(previous)) <= tolerance:
+                authored = float(previous)
+            result.append(authored)
+        else:
+            # A zero-sized primitive has no invertible displayed scale. Keep
+            # the last independent USD xform contribution until it becomes
+            # representable again.
+            result.append(float(previous))
+    return result
+
+
 _USD_MESH_TYPES = ("Sphere", "Cube", "Cylinder", "Cone", "Capsule")
 
 
@@ -305,18 +345,23 @@ class USD_CONNECT_Hook(bpy.types.USDHook):
 
         # Blender may map a collapsed parent Xform to an Object while mapping
         # the represented child Mesh/Camera/Light prim to that object's data.
-        # Resolve both forms before tagging so edits target the schema prim,
-        # not the collapsed parent.
+        # Preserve both identities: typed-schema edits target the deepest data
+        # prim, while object transforms target the prim mapped to the Object.
         owners_by_data: dict[int, list] = {}
         for obj in bpy.data.objects:
             data = getattr(obj, "data", None)
             if data is not None:
                 owners_by_data.setdefault(data.as_pointer(), []).append(obj)
 
-        from .blender_adapter import _PROP_USD_IMPORTED, _PROP_USD_PRIM_ALIASES
+        from .blender_adapter import (
+            _PROP_USD_IMPORTED,
+            _PROP_USD_PRIM_ALIASES,
+            _PROP_USD_XFORM_PRIM_PATH,
+        )
 
         object_tags: dict[int, tuple[tuple[int, int], object, str, str]] = {}
         object_paths: dict[int, set[str]] = {}
+        object_xform_paths: dict[int, set[str]] = {}
         for prim_path, data_blocks in prim_map.items():
             prim_path_str = str(prim_path)
             prim_type_name = ""
@@ -342,6 +387,8 @@ class USD_CONNECT_Hook(bpy.types.USDHook):
                 for obj in objects:
                     key = obj.as_pointer()
                     object_paths.setdefault(key, set()).add(prim_path_str)
+                    if data_owner == 0:
+                        object_xform_paths.setdefault(key, set()).add(prim_path_str)
                     current = object_tags.get(key)
                     if current is None or rank > current[0]:
                         object_tags[key] = (
@@ -360,6 +407,14 @@ class USD_CONNECT_Hook(bpy.types.USDHook):
             # Reference/payload imports are remapped later by BlenderAdapter;
             # their file-internal paths must not persist as scene aliases.
             if not USD_CONNECT_Hook._skip_root_inference:
+                xform_paths = object_xform_paths.get(obj.as_pointer(), set())
+                if xform_paths:
+                    obj[_PROP_USD_XFORM_PRIM_PATH] = max(
+                        xform_paths,
+                        key=lambda path: (path.count("/"), path),
+                    )
+                elif _PROP_USD_XFORM_PRIM_PATH in obj:
+                    del obj[_PROP_USD_XFORM_PRIM_PATH]
                 aliases = sorted(
                     path
                     for path in object_paths.get(obj.as_pointer(), set())
@@ -495,6 +550,23 @@ class BlenderStageAuthor:
             LOG.info("Auto-tracked %r -> %s (%s)", obj.name, prim_path, type_name)
         return prim_path, type_name
 
+    @staticmethod
+    def _resolve_xform_prim_path(obj, prim_path: str) -> str:
+        """Return the USD prim that owns ``obj``'s local transform.
+
+        A Blender USD import can represent a parent Xform and its typed child
+        with one object. ``usd_prim_path`` intentionally identifies the typed
+        child for geometry and material edits; the import hook records the
+        separately mapped transform owner when that collapse occurs.
+        """
+        from .blender_adapter import _PROP_USD_XFORM_PRIM_PATH
+
+        original = getattr(obj, "original", obj)
+        xform_prim_path = original.get(_PROP_USD_XFORM_PRIM_PATH)
+        if isinstance(xform_prim_path, str) and xform_prim_path:
+            return xform_prim_path
+        return prim_path
+
     def _is_under_unloaded_payload(self, prim_path: str) -> bool:
         """Check if prim_path is under a known unloaded payload root."""
         return any(prim_path.startswith(root + "/") for root in self._unloaded_payload_roots)
@@ -529,7 +601,9 @@ class BlenderStageAuthor:
             if not pp:
                 break
             if pp in self._prim_refs:
-                break  # already tracked — already has ops
+                prim = self.stage.GetPrimAtPath(pp)
+                if prim and prim.IsValid():
+                    break  # tracked and represented on the local author stage
             ancestors.append((ancestor, pp))
             ancestor = ancestor.parent
 
@@ -537,9 +611,10 @@ class BlenderStageAuthor:
         # depsgraph updates handle actual edits.
         for anc_obj, anc_path in reversed(ancestors):
             existed = bool(self.stage.GetPrimAtPath(anc_path))
+            was_tracked = anc_path in self._prim_refs
             tn = anc_obj.get("usd_type_name", "Xform")
             self._ensure_local_prim(anc_path, anc_obj, tn)
-            if not existed and not self._is_imported_object(anc_obj):
+            if not existed and not was_tracked and not self._is_imported_object(anc_obj):
                 self._ensure_xform_ops(anc_path)
                 self._author_xform(anc_path, anc_obj)
             self._prim_refs[anc_path] = anc_obj
@@ -585,7 +660,7 @@ class BlenderStageAuthor:
 
         tx, ty, tz = loc.x, loc.y, loc.z
         rw, rx, ry, rz = rot_quat.w, rot_quat.x, rot_quat.y, rot_quat.z
-        sx, sy, sz = scl.x, scl.y, scl.z
+        sx, sy, sz = _usd_xform_scale(obj, (scl.x, scl.y, scl.z))
 
         if self._needs_axis_conv and not parent_handles:
             # T and S always need Z-up → Y-up conversion.
@@ -873,6 +948,7 @@ class BlenderStageAuthor:
             prim_path, type_name = self._resolve_prim_path(obj)
             if not prim_path:
                 continue
+            xform_prim_path = self._resolve_xform_prim_path(obj, prim_path)
 
             # Store the *original* (non-evaluated) object reference for
             # deletion detection and identity lookups in _resolve_prim_path.
@@ -906,11 +982,20 @@ class BlenderStageAuthor:
                 tn = type_name if type_name else obj_orig.get("usd_type_name", "Xform")
                 self._ensure_local_prim(prim_path, obj_orig, tn)
 
+            # A collapsed import can use one Blender object for a parent Xform
+            # and a typed child. Ensure and author the object transform on its
+            # recorded USD owner without changing the typed child identity used
+            # by camera, geometry, and material capture.
+            xform_prim = self.stage.GetPrimAtPath(xform_prim_path)
+            if not xform_prim or not xform_prim.IsValid():
+                obj_orig = getattr(obj, "original", obj)
+                self._ensure_local_prim(xform_prim_path, obj_orig, "Xform")
+
             # ALWAYS ensure canonical xform ops before authoring
-            self._ensure_xform_ops(prim_path)
+            self._ensure_xform_ops(xform_prim_path)
 
             # Author TRS
-            self._author_xform(prim_path, obj)
+            self._author_xform(xform_prim_path, obj)
 
             if obj.type == "CAMERA":
                 self._author_camera_attrs(prim_path, obj)

--- a/openusdconnect/adapters.py
+++ b/openusdconnect/adapters.py
@@ -299,6 +299,29 @@ class DCCAdapter(ABC):
         """
         return False
 
+    def native_composition_subtree_roots(self, events: list[dict]) -> set[str]:
+        """Return composition roots this batch materializes natively.
+
+        Some external-scene adapters implement references, loaded payloads,
+        or variants by asking the DCC's USD importer to build the complete
+        composed subtree. For those roots, composed projection must not also
+        synthesize notice-discovered descendant lifecycle, geometry, material,
+        and shader events: replaying them would overwrite the higher-fidelity
+        native import.
+
+        The declaration affects only candidates discovered indirectly from
+        USD composition notices. Explicit descendant edits in ``events`` are
+        still projected and delivered after the root composition operation.
+        Adapters that construct descendants solely from projected events must
+        keep the default empty result.
+
+        Implementations must return a root only when applying the batch's
+        composition event will import, re-import, or remove that subtree. As
+        with :meth:`apply_events`, failure to realize a declared operation must
+        raise rather than silently returning ``False``.
+        """
+        return set()
+
     @abstractmethod
     def delete_prim(self, prim_path: str) -> bool:
         raise NotImplementedError

--- a/openusdconnect/composed_projection.py
+++ b/openusdconnect/composed_projection.py
@@ -96,6 +96,30 @@ class _ProjectionCandidates:
     arcs: set[tuple[str, str]] = dataclass_field(default_factory=set)
 
 
+def _copy_projection_candidates(source: _ProjectionCandidates) -> _ProjectionCandidates:
+    """Copy candidate membership so later notice additions retain provenance."""
+    return _ProjectionCandidates(
+        prims=set(source.prims),
+        types=set(source.types),
+        xforms=set(source.xforms),
+        gprim=defaultdict(set, {key: set(value) for key, value in source.gprim.items()}),
+        variants=set(source.variants),
+        materials=set(source.materials),
+        connectables=defaultdict(
+            set,
+            {key: set(value) for key, value in source.connectables.items()},
+        ),
+        active=set(source.active),
+        visibility=set(source.visibility),
+        instanceable=set(source.instanceable),
+        point_instancers=defaultdict(
+            set,
+            {key: set(value) for key, value in source.point_instancers.items()},
+        ),
+        arcs=set(source.arcs),
+    )
+
+
 @dataclass(slots=True)
 class _PrimProjectionValues:
     """Adapter-visible values read for one affected composed prim."""
@@ -887,6 +911,7 @@ class ComposedChangeProjection:
         extra_arc_candidates: Iterable[tuple[str, str]] = (),
         reapply_all_composed: bool = False,
         reapply_composed_paths: Iterable[str] = (),
+        native_composition_subtree_roots: Iterable[str] = (),
         reset: bool = False,
     ):
         self._stage = stage
@@ -903,6 +928,9 @@ class ComposedChangeProjection:
         self._built_adapter_events: list[dict] | None = None
         self._delivery_state = "open"
         self._notice_key = None
+        self._native_composition_subtree_roots = self._minimal_roots(
+            str(path) for path in native_composition_subtree_roots if path
+        )
         self._prepare_reapplication_scope(
             reapply_all_composed=reapply_all_composed,
             reapply_composed_paths=reapply_composed_paths,
@@ -915,6 +943,11 @@ class ComposedChangeProjection:
             initial_prim_paths,
             initial_scene_paths,
             extra_arc_candidates,
+        )
+        self._pre_notice_candidates = (
+            _copy_projection_candidates(self._candidates)
+            if self._native_composition_subtree_roots
+            else None
         )
         self._previous_values: _ProjectionValues | None = None
         if self._state.needs_full_reconcile:
@@ -974,6 +1007,15 @@ class ComposedChangeProjection:
             if old_path in self._reapply_composed_paths
         )
         self._subtree_roots = {path for pair in self._rename_pairs for path in pair[:2]}
+        self._explicit_lifecycle_paths = {
+            str(event["prim"])
+            for event in events
+            if event.get("prim")
+            and event.get("k") in {K_ENSURE_PRIM, K_DELETE_PRIM, K_RENAME_PRIM}
+        }
+        self._explicit_lifecycle_paths.update(
+            new_path for _old_path, new_path, _event in self._rename_pairs
+        )
         for event in events:
             if event.get("k") == K_DELETE_PRIM and event.get("prim"):
                 self._subtree_roots.add(str(event["prim"]))
@@ -1001,6 +1043,13 @@ class ComposedChangeProjection:
             for old_path, new_path, _event in self._rename_pairs
             if old_path in self._local_lifecycle_paths
         )
+        self._local_requested_types = {
+            str(event["prim"]): str(event.get("typeName") or "")
+            for event in events
+            if event.get("k") == K_ENSURE_PRIM
+            and event.get("prim")
+            and str(event["prim"]) in self._local_lifecycle_paths
+        }
 
     def _prepare_scene_scope(
         self,
@@ -1505,6 +1554,116 @@ class ComposedChangeProjection:
         paths.update(key[0] for key in candidates.arcs)
         self._affected_prim_paths = {path for path in paths if path and path != "/"}
 
+    def _is_in_native_composition_subtree(self, prim_path: str) -> bool:
+        return any(
+            _path_is_at_or_below(prim_path, root)
+            for root in self._native_composition_subtree_roots
+        )
+
+    def _remove_native_owned_notice_candidates(self) -> None:
+        """Drop only candidates added by notices beneath native-import roots."""
+        if not self._native_composition_subtree_roots:
+            return
+
+        current = self._candidates
+        initial = self._pre_notice_candidates
+        if initial is None:
+            raise RuntimeError("native composition roots require candidate provenance")
+
+        def _prune_set(values, original, path_of):
+            values.difference_update(
+                {
+                    value
+                for value in values
+                if value not in original
+                and self._is_in_native_composition_subtree(path_of(value))
+                }
+            )
+
+        current.prims.difference_update(
+            {
+                prim_path
+                for prim_path in current.prims
+                if self._is_in_native_composition_subtree(prim_path)
+                and prim_path not in self._native_composition_subtree_roots
+                and prim_path not in self._explicit_lifecycle_paths
+                and prim_path not in initial.types
+            }
+        )
+        _prune_set(current.types, initial.types, lambda value: value)
+        _prune_set(current.xforms, initial.xforms, lambda value: value[0])
+        _prune_set(current.variants, initial.variants, lambda value: value)
+        _prune_set(current.materials, initial.materials, lambda value: value[0])
+        _prune_set(current.active, initial.active, lambda value: value)
+        _prune_set(current.visibility, initial.visibility, lambda value: value[0])
+        _prune_set(current.instanceable, initial.instanceable, lambda value: value)
+        _prune_set(current.arcs, initial.arcs, lambda value: value[0])
+
+        for values, original in (
+            (current.gprim, initial.gprim),
+            (current.connectables, initial.connectables),
+            (current.point_instancers, initial.point_instancers),
+        ):
+            for key in tuple(values):
+                if not self._is_in_native_composition_subtree(key[0]):
+                    continue
+                values[key].intersection_update(original.get(key, ()))
+                if not values[key]:
+                    del values[key]
+
+    def _order_native_composition_events(self, events: list[dict]) -> list[dict]:
+        """Place explicit descendant lifecycle after its native root import."""
+        if not self._native_composition_subtree_roots:
+            return events
+
+        control_kinds = {
+            K_SET_REFERENCE,
+            K_SET_PAYLOAD,
+            K_LOAD_PAYLOAD,
+            K_UNLOAD_PAYLOAD,
+            K_SET_VARIANT_SELECTIONS,
+        }
+        lifecycle_kinds = {K_ENSURE_PRIM, K_DELETE_PRIM, K_RENAME_PRIM}
+        last_control = {}
+        for index, event in enumerate(events):
+            prim_path = str(event.get("prim") or "")
+            if event.get("k") not in control_kinds:
+                continue
+            for root in self._native_composition_subtree_roots:
+                if prim_path == root:
+                    last_control[root] = index
+
+        deferred = defaultdict(list)
+        retained = []
+        for index, event in enumerate(events):
+            prim_path = str(event.get("prim") or "")
+            owner = next(
+                (
+                    root
+                    for root in sorted(
+                        self._native_composition_subtree_roots,
+                        key=len,
+                        reverse=True,
+                    )
+                    if root in last_control
+                    and prim_path != root
+                    and _path_is_at_or_below(prim_path, root)
+                ),
+                None,
+            )
+            if owner is not None and event.get("k") in lifecycle_kinds:
+                deferred[owner].append(event)
+                continue
+            retained.append((index, event))
+
+        result = []
+        for index, event in retained:
+            result.append(event)
+            for root, control_index in last_control.items():
+                if control_index == index:
+                    result.extend(deferred[root])
+        return result
+
     def _previous_prim_values(self, prim_path: str) -> _PrimProjectionValues:
         if self._previous_values is None:
             raise RuntimeError("previous adapter values have not been captured")
@@ -1520,6 +1679,7 @@ class ComposedChangeProjection:
             self._add_scene_path_candidates(self._event_scene_paths)
         if self._subtree_roots:
             self._add_subtree_candidates(self._subtree_roots)
+        self._remove_native_owned_notice_candidates()
         self._record_affected_prim_paths()
         if (previous_stage := self._state.previous_stage) is not None:
             self._previous_values = self._capture_candidates(
@@ -1530,6 +1690,7 @@ class ComposedChangeProjection:
         adapter_events: list[dict] = []
         for step in _PROJECTION_STEPS:
             adapter_events.extend(getattr(self, step.method_name)())
+        adapter_events = self._order_native_composition_events(adapter_events)
         self._built_adapter_events = adapter_events
         self._delivery_state = "built"
         return adapter_events
@@ -1655,6 +1816,11 @@ class ComposedChangeProjection:
                 and self._should_reapply_composed(prim_path)
                 and not self._reset
                 and prim_path in self._local_lifecycle_paths
+                and (
+                    prim_path not in self._local_requested_types
+                    or after_type is None
+                    or self._local_requested_types[prim_path] != after_type[0]
+                )
             )
             schema_changed = prim_path in self._candidates.types and before_type != after_type
             ensure = {

--- a/openusdconnect/dispatcher.py
+++ b/openusdconnect/dispatcher.py
@@ -760,6 +760,9 @@ class EventDispatcher:
                 extra_scene_paths=stack_paths,
                 extra_arc_candidates=stack_arc_paths,
                 reapply_composed_paths=same_origin_paths,
+                native_composition_subtree_roots=(
+                    self.adapter.native_composition_subtree_roots(events)
+                ),
                 reset=reset_layers,
             )
             if projects_to_external_scene

--- a/scripts/blender_bootstrap_instance.py
+++ b/scripts/blender_bootstrap_instance.py
@@ -5,6 +5,7 @@ This script is intended to be passed to Blender with:
 
 It will:
 - install/enable the USD Connect addon from a zip
+- import the configured base USD through the addon's prim-tagging hook
 - apply host/port scene settings for emitter/receiver
 - optionally start emitter and/or receiver
 - optionally start debugpy and wait for VS Code attach
@@ -32,6 +33,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--addon-zip", required=True, help="Path to dist/usd_connect_blender.zip")
     parser.add_argument("--host", default="127.0.0.1", help="Sync server host")
     parser.add_argument("--port", type=int, default=7200, help="Sync server port")
+    parser.add_argument("--base", required=True, help="Base USD file to import")
     parser.add_argument("--role", default="instance", help="Label for logs")
     parser.add_argument("--debug-port", type=int, default=0, help="debugpy listen port; 0 disables")
     parser.add_argument("--wait-for-client", action="store_true", help="Wait for debugger attach")
@@ -76,8 +78,37 @@ def _write_addon_path() -> None:
         print(f"[USD Connect Bootstrap] could not write .blender_addon_path: {exc}")
 
 
-def _configure_scene(host: str, port: int) -> None:
+def _load_base_scene(base_usd: str) -> None:
+    """Import the authoritative base through the addon's tagging hook."""
+    base_usd = os.path.abspath(base_usd)
+    if not os.path.isfile(base_usd):
+        raise FileNotFoundError(f"Base USD file not found: {base_usd}")
+
+    # Live-enabled USD files may contain endpoint metadata. The debug launcher
+    # owns connection startup, so prevent the import operator from connecting
+    # before this script has applied its explicit host and port.
     scene = bpy.context.scene
+    if hasattr(scene, "usd_connect_live_auto_start_emitter"):
+        scene.usd_connect_live_auto_start_emitter = False
+    if hasattr(scene, "usd_connect_live_auto_start_receiver"):
+        scene.usd_connect_live_auto_start_receiver = False
+
+    # A debug instance should represent the USD base, not Blender's default
+    # cube/camera/light plus that base.
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=False)
+
+    result = bpy.ops.usd_connect.import_with_hook(filepath=base_usd)
+    if "FINISHED" not in result:
+        raise RuntimeError(f"Base USD import failed: {result}")
+    print(f"[USD Connect Bootstrap] Base USD imported: {base_usd}")
+
+
+def _configure_scene(host: str, port: int, base_usd: str) -> None:
+    scene = bpy.context.scene
+
+    if hasattr(scene, "usd_connect_base_usd_path"):
+        scene.usd_connect_base_usd_path = os.path.abspath(base_usd)
 
     if hasattr(scene, "usd_connect_emit_host"):
         scene.usd_connect_emit_host = host
@@ -192,7 +223,8 @@ def main() -> None:
     print(f"[USD Connect Bootstrap:{args.role}] starting")
 
     _ensure_addon(args.addon_zip)
-    _configure_scene(args.host, args.port)
+    _load_base_scene(args.base)
+    _configure_scene(args.host, args.port, args.base)
     _start_debugpy(args.debug_port, args.wait_for_client, args.role)
     _start_network_ops(args.start_emitter, args.start_receiver)
     _start_reload_watcher(args.addon_zip, args.role)

--- a/scripts/start_usdconnect_debug.py
+++ b/scripts/start_usdconnect_debug.py
@@ -7,8 +7,8 @@ Usage:
     uv run python scripts/start_usdconnect_debug.py --wait-for-debugger
 
 Starts the sync server, builds the addon if needed, and launches one or
-two Blender instances with the bootstrap script.  Stops the server when
-all Blender instances exit.
+two Blender instances with the base USD imported by the bootstrap script.
+Stops the server when all Blender instances exit.
 """
 
 from __future__ import annotations
@@ -103,6 +103,7 @@ def _start_server(python: str, host: str, port: int,
 
 
 def _start_blender(blender_exe: str, role: str, host: str, port: int,
+                    base_usd: str,
                     debug_port: int, wait_for_debugger: bool,
                     start_emitter: bool, start_receiver: bool) -> subprocess.Popen:
     """Start a Blender instance with the bootstrap script."""
@@ -113,6 +114,7 @@ def _start_blender(blender_exe: str, role: str, host: str, port: int,
         "--addon-zip", str(ADDON_ZIP),
         "--host", host,
         "--port", str(port),
+        "--base", base_usd,
         "--role", role,
     ]
     if debug_port > 0:
@@ -166,7 +168,7 @@ def main(argv: list[str] | None = None):
         raise SystemExit(f"Blender executable not found: {blender_exe}")
     if not BOOTSTRAP_SCRIPT.exists():
         raise SystemExit(f"Bootstrap script not found: {BOOTSTRAP_SCRIPT}")
-    if not args.no_server and not pathlib.Path(base_usd).exists():
+    if not pathlib.Path(base_usd).exists():
         raise SystemExit(f"Base USD file not found: {base_usd}")
 
     _build_addon()
@@ -183,6 +185,7 @@ def main(argv: list[str] | None = None):
     # Start Blender A
     blender_a = _start_blender(
         blender_exe, "A", args.host, args.port,
+        base_usd,
         args.debug_port, args.wait_for_debugger,
         args.start_emitter, args.start_receiver,
     )
@@ -192,6 +195,7 @@ def main(argv: list[str] | None = None):
     if args.two_blenders:
         blender_b = _start_blender(
             blender_exe, "B", args.host, args.port,
+            base_usd,
             args.debug_port_b, args.wait_for_debugger,
             args.start_emitter, args.start_receiver,
         )

--- a/tests/integration/asset_tests/test_bishop.py
+++ b/tests/integration/asset_tests/test_bishop.py
@@ -17,6 +17,34 @@ ASSET = os.path.join(
 harness = TestHarness("BISHOP")
 
 _step = 0
+
+
+def _check_render_mesh_fidelity():
+    obj = next(
+        (
+            candidate
+            for candidate in bpy.data.objects
+            if candidate.get("usd_prim_path") == "/World/Bishop/Geom/Render"
+        ),
+        None,
+    )
+    if obj is None or obj.type != "MESH" or obj.data is None:
+        harness._fail("Bishop render mesh not found")
+        return
+    mesh = obj.data
+    if len(mesh.vertices) != 37464 or len(mesh.polygons) != 37528:
+        harness._fail(
+            f"Bishop mesh topology: {len(mesh.vertices)} verts, "
+            f"{len(mesh.polygons)} polygons",
+        )
+        return
+    flat_polygons = sum(not polygon.use_smooth for polygon in mesh.polygons)
+    if flat_polygons:
+        harness._fail(f"Bishop mesh has {flat_polygons} flat-shaded polygons")
+        return
+    harness._pass("Bishop native mesh fidelity: 37464 verts, 37528 smooth polygons")
+
+
 def _run():
     global _step
     if _step == 0:
@@ -40,6 +68,7 @@ def _run():
 
         # Binding
         harness.check_binding("Render", "M_Bishop_B")
+        _check_render_mesh_fidelity()
 
         # Shader maps seeded for reverse path
         harness.check_shader_maps_seeded("Bishop")

--- a/tests/integration/asset_tests/test_teapot_variants.py
+++ b/tests/integration/asset_tests/test_teapot_variants.py
@@ -48,6 +48,25 @@ def _get_bsdf_value(mat_name_contains, input_name):
     return None
 
 
+def _check_geometry_is_smooth(label):
+    obj = next(
+        (
+            candidate
+            for candidate in bpy.data.objects
+            if candidate.get("usd_prim_path") == "/World/Teapot/Geometry"
+        ),
+        None,
+    )
+    if obj is None or obj.type != "MESH" or obj.data is None:
+        harness._fail(f"{label}: Teapot geometry mesh not found")
+        return
+    flat_polygons = sum(not polygon.use_smooth for polygon in obj.data.polygons)
+    if flat_polygons:
+        harness._fail(f"{label}: {flat_polygons} flat-shaded polygons")
+        return
+    harness._pass(f"{label}: {len(obj.data.polygons)} smooth polygons")
+
+
 def _send_shader_edit(prim_path, info_id, inputs, input_types):
     """Send a set_shader_input event via CLI."""
     harness._send([{
@@ -91,6 +110,7 @@ def _run():
             harness.log("--- Phase 1: Default variant (Utah) ---")
             harness.check_binding("Geometry", "Ceramic")
             harness.check_connection("Ceramic", "Base Color", linked=True)
+            _check_geometry_is_smooth("Utah")
             _step = 3
             return 1.0
 
@@ -123,6 +143,7 @@ def _run():
             bound = _find_geometry_material()
             if bound and "Porcelain" in bound:
                 harness._pass(f"Fancy: bound to {bound}")
+                _check_geometry_is_smooth("Fancy")
                 _step = 7
                 return 1.0
             _retries += 1
@@ -162,6 +183,7 @@ def _run():
             bound = _find_geometry_material()
             if bound and "Ceramic" in bound:
                 harness._pass(f"Utah: rebound to {bound}")
+                _check_geometry_is_smooth("Utah again")
                 # Verify metallic edit survived the variant round-trip
                 harness.log("--- Phase 5b: Verify Ceramic metallic retained ---")
                 _check_value("Ceramic", "Metallic", 0.8)
@@ -186,6 +208,7 @@ def _run():
             bound = _find_geometry_material()
             if bound and "Porcelain" in bound:
                 harness._pass(f"Fancy again: bound to {bound}")
+                _check_geometry_is_smooth("Fancy again")
                 # Verify roughness edit survived
                 harness.log("--- Phase 6b: Verify PorcelainFlowers roughness retained ---")
                 _check_value("PorcelainFlowers", "Roughness", 0.3)

--- a/tests/integration/scripts/blender_adapter_test_script.py
+++ b/tests/integration/scripts/blender_adapter_test_script.py
@@ -1173,6 +1173,7 @@ def test_collapsed_import_parent_xform_alias_receives_early_event(r):
     """
     name = "test_collapsed_import_parent_xform_alias_receives_early_event"
     _clear_scene()
+    from integrations.blender.blender_adapter import _PROP_USD_XFORM_PRIM_PATH
     from integrations.blender.capture import USD_CONNECT_Hook, _ensure_scene_props
 
     _ensure_scene_props()
@@ -1187,6 +1188,13 @@ def test_collapsed_import_parent_xform_alias_receives_early_event(r):
         if parent_obj is None or parent_obj is not geom_obj:
             r.fail(name, "collapsed parent and Geom paths did not resolve to one object")
             return
+        if geom_obj.get(_PROP_USD_XFORM_PRIM_PATH) != "/World/Sphere":
+            r.fail(
+                name,
+                "collapsed object's transform owner is "
+                f"{geom_obj.get(_PROP_USD_XFORM_PRIM_PATH)!r}, expected /World/Sphere",
+            )
+            return
         before_count = len(bpy.data.objects)
         if not adapter.set_xform_trs("/World/Sphere", t=[0.0, 1.5, 0.0]):
             r.fail(name, "parent transform event was not applied")
@@ -1199,6 +1207,74 @@ def test_collapsed_import_parent_xform_alias_receives_early_event(r):
             return
         if len(bpy.data.objects) != before_count:
             r.fail(name, "ensure_prim created a duplicate parent Empty")
+            return
+    finally:
+        if registered_here:
+            bpy.utils.unregister_class(USD_CONNECT_Hook)
+    r.ok(name)
+
+
+def test_collapsed_import_reverse_capture_authors_parent_xform(r):
+    """Moving a collapsed imported gprim authors its parent Xform exactly once."""
+    from pxr import UsdGeom
+
+    from integrations.blender.capture import (
+        BlenderStageAuthor,
+        USD_CONNECT_Hook,
+        _ensure_scene_props,
+    )
+    from openusdconnect.emitter import NoticeEmitter
+    from openusdconnect.protocol_constants import K_SET_XFORM_TRS
+
+    name = "test_collapsed_import_reverse_capture_authors_parent_xform"
+    _clear_scene()
+    _ensure_scene_props()
+    registered_here = not hasattr(bpy.types, USD_CONNECT_Hook.__name__)
+    if registered_here:
+        bpy.utils.register_class(USD_CONNECT_Hook)
+    try:
+        base_path = os.path.join(project_root, "test_scene.usda")
+        bpy.ops.wm.usd_import(filepath=base_path)
+        adapter = BlenderAdapter()
+        cylinder = _find_by_prim(adapter, "/World/Cylinder/Geom")
+        if cylinder is None or _find_by_prim(adapter, "/World/Cylinder") is not cylinder:
+            r.fail(name, "Cylinder parent and Geom were not collapsed onto one object")
+            return
+
+        author = BlenderStageAuthor(base_usd_path=base_path)
+        author.enabled = True
+        emitter = NoticeEmitter(author.stage)
+
+        cylinder.location.x += 1.0
+        bpy.context.view_layer.update()
+
+        class _Update:
+            def __init__(self, obj):
+                self.id = obj
+
+        author.on_depsgraph_update([_Update(cylinder)])
+        events = [
+            event
+            for event in emitter.build_events_for_dirty()
+            if event["k"] == K_SET_XFORM_TRS
+        ]
+        parent_events = [event for event in events if event["prim"] == "/World/Cylinder"]
+        child_events = [event for event in events if event["prim"] == "/World/Cylinder/Geom"]
+        if not parent_events or child_events:
+            r.fail(
+                name,
+                f"expected parent-only transform event; parent={parent_events}, child={child_events}",
+            )
+            return
+
+        child = author.stage.GetPrimAtPath("/World/Cylinder/Geom")
+        if UsdGeom.Xformable(child).GetOrderedXformOps():
+            r.fail(name, "reverse capture authored transform ops on the Geom child")
+            return
+        world_t = UsdGeom.XformCache().GetLocalToWorldTransform(child).ExtractTranslation()
+        got = tuple(round(float(value), 6) for value in world_t)
+        if got != (1.0, 0.0, 2.0):
+            r.fail(name, f"composed Cylinder position={got}, expected (1.0, 0.0, 2.0)")
             return
     finally:
         if registered_here:
@@ -1432,6 +1508,82 @@ def test_texture_swap_reverse_sync(r):
     r.ok(name)
 
 
+def test_distinct_material_root_connections_use_exact_paths(r):
+    """Material-root output connections resolve the exact per-piece graph.
+
+    Two materials deliberately share the leaf name ``Wood``. Full USD paths
+    must keep their Blender materials separate, and a connection authored on
+    either Material prim must find that exact registered material instead of
+    walking past it to ``/World/Looks``.
+    """
+    name = "test_distinct_material_root_connections_use_exact_paths"
+    _clear_scene()
+    adapter = BlenderAdapter()
+    cases = [
+        (
+            "/World/Chair/Seat",
+            "/World/Looks/Seat/Wood",
+            [0.4, 0.2, 0.1],
+        ),
+        (
+            "/World/Chair/Backrest",
+            "/World/Looks/Backrest/Wood",
+            [0.1, 0.2, 0.4],
+        ),
+    ]
+    materials = []
+    for object_path, material_path, color in cases:
+        shader_path = f"{material_path}/Surface"
+        adapter.ensure_prim(object_path, "Cube")
+        adapter.set_material_binding(object_path, material_path)
+        adapter.set_connectable_input(
+            shader_path,
+            "UsdPreviewSurface",
+            {"diffuseColor": color, "roughness": 0.5},
+            {"diffuseColor": "color3f", "roughness": "float"},
+        )
+        applied = adapter.set_connectable_connection(
+            material_path,
+            {
+                "outputs:surface": {
+                    "source_prim": shader_path,
+                    "source_attr": "outputs:surface",
+                }
+            },
+            [],
+        )
+        material = adapter._find_material_for_shader(material_path)
+        if not applied or material is None:
+            r.fail(name, f"material-root connection did not resolve {material_path}")
+            return
+        if material.get("usd_material_path") != material_path:
+            r.fail(
+                name,
+                f"resolved {material.name} with path {material.get('usd_material_path')!r} "
+                f"for {material_path}",
+            )
+            return
+        tagged_nodes = [
+            node
+            for node in material.node_tree.nodes
+            if node.get("usd_shader_path") == shader_path
+        ]
+        outputs = [
+            node
+            for node in material.node_tree.nodes
+            if node.type == "OUTPUT_MATERIAL"
+        ]
+        if not tagged_nodes or not outputs or not outputs[0].inputs["Surface"].is_linked:
+            r.fail(name, f"incomplete surface graph for {material_path}")
+            return
+        materials.append(material)
+
+    if materials[0] == materials[1]:
+        r.fail(name, "distinct full USD material paths reused one Blender material")
+        return
+    r.ok(name)
+
+
 def test_capture_camera_move_emits_trs_only(r):
     """After first encounter, moving the camera emits set_xform_trs but no
     camera attrs event (params unchanged → CameraAttrsChannel.diff is empty)."""
@@ -1614,12 +1766,14 @@ def main():
         test_set_gprim_attrs_camera_full_roundtrip,
         test_set_gprim_attrs_camera_receive_only_uses_scene_units,
         test_collapsed_import_parent_xform_alias_receives_early_event,
+        test_collapsed_import_reverse_capture_authors_parent_xform,
         test_set_gprim_attrs_camera_orthographic,
         test_set_gprim_attrs_camera_fstop_zero_disables_dof,
         test_capture_authors_camera_attrs_to_stage,
         test_capture_camera_move_emits_trs_only,
         test_capture_camera_lens_only_emits_attrs,
         test_texture_swap_reverse_sync,
+        test_distinct_material_root_connections_use_exact_paths,
     ]
 
     for t in tests:

--- a/tests/integration/scripts/remote_feedback_no_echo.py
+++ b/tests/integration/scripts/remote_feedback_no_echo.py
@@ -14,6 +14,8 @@ PROJECT_ROOT = os.path.abspath(
 ADDON_ZIP = os.path.join(PROJECT_ROOT, "dist", "usd_connect_blender.zip")
 BASE_USD = os.path.join(PROJECT_ROOT, "test_scene.usda")
 SHADER_PATH = "/World/NoEchoLooks/Material/StandardSurface"
+PARAMETRIC_PARENT_PATH = "/World/NoEchoParametricParent"
+PARAMETRIC_PATH = f"{PARAMETRIC_PARENT_PATH}/Cube"
 INITIAL_ROUGHNESS = 0.2
 UPDATED_ROUGHNESS = 0.73
 
@@ -235,6 +237,110 @@ def _test_step():
             return 2.0
 
         if _step == 6:
+            _send_external(
+                [
+                    {
+                        "k": "ensure_prim",
+                        "prim": PARAMETRIC_PARENT_PATH,
+                        "typeName": "Xform",
+                    },
+                    {"k": "ensure_prim", "prim": PARAMETRIC_PATH, "typeName": "Cube"},
+                    {
+                        "k": "set_gprim_attrs",
+                        "prim": PARAMETRIC_PATH,
+                        "attrs": {"size": 1.0},
+                    },
+                    {"k": "ensure_xform_ops", "prim": PARAMETRIC_PATH},
+                    {
+                        "k": "set_xform_trs",
+                        "prim": PARAMETRIC_PATH,
+                        "fields": ["t", "s"],
+                        "t": [0.0, 0.0, 0.0],
+                        "s": [0.2, 0.4, 0.6],
+                    },
+                ],
+            )
+            log("remote parametric Cube transaction sent")
+            _retries = 0
+            _step = 7
+            return 0.2
+
+        if _step == 7:
+            scene = bpy.context.scene
+            if int(scene.usd_connect_recv_last_seq) < 13:
+                return _wait_or_fail(
+                    f"parametric Cube replay stalled at {scene.usd_connect_recv_last_seq}",
+                )
+            obj = next(
+                (
+                    candidate
+                    for candidate in bpy.data.objects
+                    if candidate.get("usd_prim_path") == PARAMETRIC_PATH
+                ),
+                None,
+            )
+            if obj is None:
+                raise RuntimeError("remote parametric Cube was not created")
+            expected_display_scale = (0.1, 0.2, 0.3)
+            if any(
+                abs(float(actual) - expected) > 1e-4
+                for actual, expected in zip(
+                    obj.scale,
+                    expected_display_scale,
+                    strict=True,
+                )
+            ):
+                raise RuntimeError(
+                    f"unexpected initial parametric scale: {tuple(obj.scale)}",
+                )
+            log(
+                "initial parametric state: "
+                f"geometry={obj.get('usd_geom_scale')} "
+                f"xform={obj.get('usd_xform_scale')}",
+            )
+            obj.location.x += 1.0
+            bpy.context.view_layer.update()
+            log("moved remote parametric Cube locally")
+            _retries = 0
+            _step = 8
+            return 0.2
+
+        if _step == 8:
+            scene = bpy.context.scene
+            if int(scene.usd_connect_recv_last_seq) < 17:
+                return _wait_or_fail(
+                    f"local parametric edit stalled at {scene.usd_connect_recv_last_seq}",
+                )
+            log("same-origin correction applied; waiting for delayed callbacks")
+            _step = 9
+            return 2.0
+
+        if _step == 9:
+            obj = next(
+                (
+                    candidate
+                    for candidate in bpy.data.objects
+                    if candidate.get("usd_prim_path") == PARAMETRIC_PATH
+                ),
+                None,
+            )
+            if obj is None:
+                raise RuntimeError("parametric Cube disappeared after correction")
+            expected_display_scale = (0.1, 0.2, 0.3)
+            if any(
+                abs(float(actual) - expected) > 1e-4
+                for actual, expected in zip(
+                    obj.scale,
+                    expected_display_scale,
+                    strict=True,
+                )
+            ):
+                raise RuntimeError(
+                    "parametric scale changed after round trip: "
+                    f"display={tuple(obj.scale)} "
+                    f"geometry={obj.get('usd_geom_scale')} "
+                    f"xform={obj.get('usd_xform_scale')}",
+                )
             if _sender is not None:
                 _sender.disconnect()
                 _sender = None

--- a/tests/integration/test_blender_remote_echo.py
+++ b/tests/integration/test_blender_remote_echo.py
@@ -7,6 +7,9 @@ import sqlite3
 import subprocess
 import sys
 
+import pytest
+
+from openusdconnect.codec import message_to_dict
 from tests.helpers import PROJECT_ROOT, run_blender, start_server, stop_server
 
 SCRIPT = os.path.join(
@@ -52,12 +55,12 @@ def test_remote_transform_and_materialx_changes_are_not_echoed(
         db_path = tmp_path / f"events_{free_port}.db"
         with sqlite3.connect(db_path) as connection:
             rows = connection.execute(
-                "SELECT seq, client_id, kind, prim FROM events ORDER BY seq",
+                "SELECT seq, client_id, kind, prim, event_bin FROM events ORDER BY seq",
             ).fetchall()
 
         external = "remote-feedback-no-echo-external"
         shader_path = "/World/NoEchoLooks/Material/StandardSurface"
-        assert [row[:3] for row in rows] == [
+        assert [row[:3] for row in rows[:8]] == [
             (1, external, "ensure_prim"),
             (2, external, "ensure_xform_ops"),
             (3, external, "set_xform_trs"),
@@ -75,6 +78,30 @@ def test_remote_transform_and_materialx_changes_are_not_echoed(
             shader_path,
             shader_path,
             shader_path,
+            "/World/NoEchoParametricParent",
+            "/World/NoEchoParametricParent/Cube",
+            "/World/NoEchoParametricParent/Cube",
+            "/World/NoEchoParametricParent/Cube",
+            "/World/NoEchoParametricParent/Cube",
+            "/World/NoEchoParametricParent",
+            "/World/NoEchoParametricParent/Cube",
+            "/World/NoEchoParametricParent/Cube",
+            "/World/NoEchoParametricParent/Cube",
         ]
+        assert [row[2] for row in rows[8:13]] == [
+            "ensure_prim",
+            "ensure_prim",
+            "set_gprim_attrs",
+            "ensure_xform_ops",
+            "set_xform_trs",
+        ]
+        assert [row[2] for row in rows[13:]] == [
+            "ensure_prim",
+            "ensure_prim",
+            "ensure_xform_ops",
+            "set_xform_trs",
+        ]
+        round_trip = message_to_dict(rows[-1][4])["event"]
+        assert round_trip["s"] == pytest.approx([0.2, 0.4, 0.6])
     finally:
         stop_server(server)

--- a/tests/unit/test_blender_stage_author.py
+++ b/tests/unit/test_blender_stage_author.py
@@ -10,7 +10,8 @@ import tempfile
 import types
 from unittest.mock import MagicMock
 
-from pxr import Sdf
+import pytest
+from pxr import Sdf, UsdGeom
 
 
 # ---------------------------------------------------------------------------
@@ -399,6 +400,46 @@ class TestAutoTrack:
         assert len(trs) == 1
         assert trs[0]["t"] == [1.0, 0.0, 0.0]
 
+    def test_seeded_remote_parent_is_authored_before_edited_child(self):
+        """A receive-side cache entry does not imply a local USD spec exists."""
+        world = MockBlenderObject("World", prim_path="/World", obj_type="EMPTY")
+        parent = MockBlenderObject(
+            "RemoteParent",
+            prim_path="/World/RemoteParent",
+            type_name="Xform",
+            obj_type="EMPTY",
+        )
+        child = MockBlenderObject(
+            "RemoteCube",
+            loc=(1, 0, 0),
+            prim_path="/World/RemoteParent/Cube",
+            type_name="Cube",
+        )
+        parent.parent = world
+        child.parent = parent
+        sys.modules["bpy"].data.objects = _BlenderObjectList([world, parent, child])
+        author, emitter = _make_author_and_emitter()
+        author._prim_refs.update(
+            {
+                "/World/RemoteParent": parent,
+                "/World/RemoteParent/Cube": child,
+            }
+        )
+
+        events = _get_events(author, emitter, [MockDepsgraphUpdate(child)])
+
+        ensures = [event for event in events if event["k"] == K_ENSURE_PRIM]
+        assert [(event["prim"], event["typeName"]) for event in ensures] == [
+            ("/World/RemoteParent", "Xform"),
+            ("/World/RemoteParent/Cube", "Cube"),
+        ]
+        assert not [
+            event
+            for event in events
+            if event["prim"] == "/World/RemoteParent"
+            and event["k"] in {K_ENSURE_XFORM_OPS, K_SET_XFORM_TRS}
+        ]
+
     def test_auto_track_disambiguates_collision(self):
         world = self._make_world_parent()
         existing = MockBlenderObject("Geom", prim_path="/World/Cube")
@@ -428,6 +469,49 @@ class TestAutoTrack:
         ensures = [e for e in events if e["k"] == K_ENSURE_PRIM]
         child_ensures = [e for e in ensures if e["prim"] == "/World/Sphere"]
         assert len(child_ensures) == 1
+
+
+def test_parametric_geometry_scale_is_not_authored_as_xform_scale():
+    """A receive/emit round trip must not multiply Cube sizing repeatedly."""
+    obj = MockBlenderObject(
+        "ChairLeg",
+        scl=(0.025, 0.025, 0.425),
+        prim_path="/World/ChairLeg",
+        type_name="Cube",
+    )
+    obj["usd_geom_scale"] = (0.5, 0.5, 0.5)
+    obj["usd_xform_scale"] = (0.05, 0.05, 0.85)
+    sys.modules["bpy"].data.objects = _BlenderObjectList([obj])
+    author, _emitter = _make_author_and_emitter()
+    UsdGeom.Cube.Define(author.stage, "/World/ChairLeg")
+    author._ensure_xform_ops("/World/ChairLeg")
+
+    author._author_xform("/World/ChairLeg", obj)
+
+    scale_op = next(
+        op
+        for op in UsdGeom.Xformable(author.stage.GetPrimAtPath("/World/ChairLeg"))
+        .GetOrderedXformOps()
+        if op.GetOpType() == UsdGeom.XformOp.TypeScale
+    )
+    # Blender Z-up (0.05, 0.05, 0.85) converts back to USD Y-up.
+    assert tuple(scale_op.Get()) == pytest.approx((0.05, 0.85, 0.05))
+
+
+def test_parametric_scale_round_trip_noise_keeps_previous_usd_value():
+    """Float32 display rounding must not make scale drift on every move."""
+    from integrations.blender.capture import _usd_xform_scale
+
+    obj = MockBlenderObject("ChairBackrest")
+    obj["usd_geom_scale"] = (0.5, 0.5, 0.5)
+    obj["usd_xform_scale"] = (0.42, 0.3, 0.04)
+
+    authored = _usd_xform_scale(
+        obj,
+        (0.210000008, 0.150000006, 0.0199999996),
+    )
+
+    assert authored == [0.42, 0.3, 0.04]
 
 
 class TestFirstEncounter:
@@ -707,6 +791,37 @@ class TestBlenderAssetArcProjection:
         stage.GetRootLayer().defaultPrim = name
         stage.GetRootLayer().Save()
         return str(path)
+
+    def test_native_composition_roots_cover_import_and_payload_lifecycle(self):
+        adapter = BlenderAdapter()
+
+        roots = adapter.native_composition_subtree_roots(
+            [
+                {"k": "set_reference", "prim": "/World/Reference", "refs": []},
+                {"k": "set_payload", "prim": "/World/Payload", "payloads": []},
+                {"k": "load_payload", "prim": "/World/Payload"},
+                {"k": "unload_payload", "prim": "/World/Unloaded"},
+            ]
+        )
+
+        assert roots == {
+            "/World/Reference",
+            "/World/Payload",
+            "/World/Unloaded",
+        }
+
+    def test_variant_owns_subtree_only_after_native_import(self, monkeypatch):
+        adapter = BlenderAdapter()
+        event = {
+            "k": "set_variant_selections",
+            "prim": "/World/Asset",
+            "selections": {"model": "B"},
+        }
+
+        assert adapter.native_composition_subtree_roots([event]) == set()
+
+        monkeypatch.setattr(adapter, "has_imported_children", lambda path: path == "/World/Asset")
+        assert adapter.native_composition_subtree_roots([event]) == {"/World/Asset"}
 
     def test_reference_projection_uses_composed_list_op(self, tmp_path):
         from pxr import Sdf, Usd

--- a/tests/unit/test_composed_projection.py
+++ b/tests/unit/test_composed_projection.py
@@ -981,6 +981,104 @@ def test_layered_dispatcher_does_not_rebuild_native_prim_for_local_api_edit():
     assert "MaterialBindingAPI" in native["api_schemas"]
 
 
+def test_layered_dispatcher_preserves_native_prim_for_matching_local_type():
+    stage = Usd.Stage.CreateInMemory()
+    receiver = _LayeredQueue(
+        [
+            encode_message(
+                _state(
+                    1,
+                    [
+                        (_STRONG_LAYER, "Strong", False),
+                        (_WEAK_LAYER, "Local", False),
+                    ],
+                )
+            ),
+            _event(
+                1,
+                _STRONG_LAYER,
+                {"k": "ensure_prim", "prim": "/World/Thing", "typeName": "Cube"},
+            ),
+        ]
+    )
+    receiver.origin = "local-origin"
+    adapter = MockAdapter()
+    dispatcher = EventDispatcher(receiver=receiver, adapter=adapter, mirror_stage=stage)
+    dispatcher.drain_and_apply()
+    adapter.get_prim("/World/Thing")["sentinel"] = True
+
+    receiver.messages = [
+        encode_message(
+            {
+                "type": "event",
+                "seq": 2,
+                "origin": "local-origin",
+                "layer_key": _WEAK_LAYER,
+                "event": {
+                    "k": "ensure_prim",
+                    "prim": "/World/Thing",
+                    "typeName": "Cube",
+                },
+            }
+        )
+    ]
+    dispatcher.drain_and_apply()
+
+    assert adapter.get_prim("/World/Thing")["sentinel"] is True
+
+
+def test_layered_dispatcher_rebuilds_native_prim_for_masked_local_type():
+    stage = Usd.Stage.CreateInMemory()
+    receiver = _LayeredQueue(
+        [
+            encode_message(
+                _state(
+                    1,
+                    [
+                        (_STRONG_LAYER, "Strong", False),
+                        (_WEAK_LAYER, "Local", False),
+                    ],
+                )
+            ),
+            _event(
+                1,
+                _STRONG_LAYER,
+                {"k": "ensure_prim", "prim": "/World/Thing", "typeName": "Cube"},
+            ),
+        ]
+    )
+    receiver.origin = "local-origin"
+    adapter = MockAdapter()
+    dispatcher = EventDispatcher(receiver=receiver, adapter=adapter, mirror_stage=stage)
+    dispatcher.drain_and_apply()
+
+    # Model the native application changing the object before its weaker local
+    # opinion returns from the server. The stronger Cube must win and replace it.
+    native = adapter.get_prim("/World/Thing")
+    native["typeName"] = "Sphere"
+    native["sentinel"] = True
+    receiver.messages = [
+        encode_message(
+            {
+                "type": "event",
+                "seq": 2,
+                "origin": "local-origin",
+                "layer_key": _WEAK_LAYER,
+                "event": {
+                    "k": "ensure_prim",
+                    "prim": "/World/Thing",
+                    "typeName": "Sphere",
+                },
+            }
+        )
+    ]
+    dispatcher.drain_and_apply()
+
+    corrected = adapter.get_prim("/World/Thing")
+    assert corrected["typeName"] == "Cube"
+    assert "sentinel" not in corrected
+
+
 def test_local_reapplication_does_not_rebuild_unrelated_remote_lifecycle():
     stage = Usd.Stage.CreateInMemory()
     receiver = _LayeredQueue(
@@ -1864,6 +1962,119 @@ def test_layered_dispatcher_projects_arcs_before_dependent_native_edits(tmp_path
     assert adapter.calls == [
         ("set_reference", "/World/Asset"),
         ("set_material_binding", "/World/Asset"),
+    ]
+
+
+def _native_import_projection_fixture(tmp_path):
+    asset_path = tmp_path / "native-import-asset.usda"
+    asset_stage = Usd.Stage.CreateNew(str(asset_path))
+    asset_stage.DefinePrim("/Asset", "Xform")
+    mesh = UsdGeom.Mesh.Define(asset_stage, "/Asset/Geom")
+    mesh.CreatePointsAttr([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)])
+    mesh.CreateFaceVertexCountsAttr([3])
+    mesh.CreateFaceVertexIndicesAttr([0, 1, 2])
+    asset_stage.GetRootLayer().defaultPrim = "Asset"
+    asset_stage.GetRootLayer().Save()
+    return asset_path
+
+
+class _NativeImportRecordingAdapter(MockAdapter):
+    def __init__(self):
+        super().__init__()
+        self.applied = []
+
+    def native_composition_subtree_roots(self, events):
+        return {
+            event["prim"]
+            for event in events
+            if event.get("k") == "set_reference" and event.get("prim")
+        }
+
+    def apply_event(self, event):
+        self.applied.append((event["k"], event.get("prim")))
+        return super().apply_event(event)
+
+    def set_reference(self, prim_path, refs, **kwargs):
+        result = super().set_reference(prim_path, refs, **kwargs)
+        self.ensure_prim(f"{prim_path}/Geom", "Mesh")
+        return result
+
+
+def _native_import_dispatcher(asset_path, *extra_events):
+    stage = Usd.Stage.CreateInMemory()
+    events = [
+        {"k": "ensure_prim", "prim": "/World/Asset", "typeName": "Xform"},
+        {
+            "k": "set_reference",
+            "prim": "/World/Asset",
+            "refs": [{"asset_path": str(asset_path), "prim_path": "/Asset"}],
+        },
+        *extra_events,
+    ]
+    receiver = _LayeredQueue(
+        [
+            encode_message(_state(1, [(_BASE_LAYER, "Base", False)])),
+            *[
+                _event(index, _BASE_LAYER, event)
+                for index, event in enumerate(events, start=1)
+            ],
+        ]
+    )
+    adapter = _NativeImportRecordingAdapter()
+    dispatcher = EventDispatcher(receiver=receiver, adapter=adapter, mirror_stage=stage)
+    dispatcher.drain_and_apply()
+    return adapter
+
+
+def test_native_import_owns_notice_discovered_reference_subtree(tmp_path):
+    asset_path = _native_import_projection_fixture(tmp_path)
+
+    adapter = _native_import_dispatcher(asset_path)
+
+    assert adapter.applied == [
+        ("ensure_prim", "/World/Asset"),
+        ("set_reference", "/World/Asset"),
+    ]
+
+
+def test_native_import_preserves_explicit_descendant_value_edit(tmp_path):
+    asset_path = _native_import_projection_fixture(tmp_path)
+    points = [(0.0, 0.0, 0.0), (2.0, 0.0, 0.0), (0.0, 2.0, 0.0)]
+
+    adapter = _native_import_dispatcher(
+        asset_path,
+        {
+            "k": "set_gprim_attrs",
+            "prim": "/World/Asset/Geom",
+            "attrs": {"points": points},
+        },
+    )
+
+    assert adapter.applied == [
+        ("ensure_prim", "/World/Asset"),
+        ("set_reference", "/World/Asset"),
+        ("set_gprim_attrs", "/World/Asset/Geom"),
+    ]
+    actual_points = adapter.get_prim("/World/Asset/Geom")["gprim_attrs"]["points"]
+    assert [tuple(point) for point in actual_points] == points
+
+
+def test_native_import_precedes_explicit_new_descendant(tmp_path):
+    asset_path = _native_import_projection_fixture(tmp_path)
+
+    adapter = _native_import_dispatcher(
+        asset_path,
+        {
+            "k": "ensure_prim",
+            "prim": "/World/Asset/AddedLocally",
+            "typeName": "Xform",
+        },
+    )
+
+    assert adapter.applied == [
+        ("ensure_prim", "/World/Asset"),
+        ("set_reference", "/World/Asset"),
+        ("ensure_prim", "/World/Asset/AddedLocally"),
     ]
 
 

--- a/tests/unit/test_start_usdconnect_debug.py
+++ b/tests/unit/test_start_usdconnect_debug.py
@@ -42,3 +42,46 @@ def test_start_server_forwards_host_and_canonical_event_log(monkeypatch):
         "events.db",
     ]
     assert kwargs["cwd"] == str(launcher.REPO_ROOT)
+
+
+def test_start_blender_forwards_base_before_network_flags(monkeypatch):
+    launcher = _load_launcher()
+    calls = []
+    monkeypatch.setattr(
+        launcher.subprocess,
+        "Popen",
+        lambda command, **kwargs: calls.append((command, kwargs)),
+    )
+
+    launcher._start_blender(
+        "blender",
+        "B",
+        "10.0.0.5",
+        7210,
+        "scene.usda",
+        0,
+        False,
+        True,
+        True,
+    )
+
+    command, kwargs = calls[0]
+    assert command == [
+        "blender",
+        "--python",
+        str(launcher.BOOTSTRAP_SCRIPT),
+        "--",
+        "--addon-zip",
+        str(launcher.ADDON_ZIP),
+        "--host",
+        "10.0.0.5",
+        "--port",
+        "7210",
+        "--base",
+        "scene.usda",
+        "--role",
+        "B",
+        "--start-emitter",
+        "--start-receiver",
+    ]
+    assert kwargs["cwd"] == str(launcher.REPO_ROOT)


### PR DESCRIPTION
Add an adapter ownership contract for composition roots materialized by native USD importers. Suppress only notice-derived descendant projection beneath those roots while preserving explicit descendant overrides and applying them after native import.

Improve Blender synchronization by importing the configured base scene, preserving collapsed USD path identities, authoring transforms on their actual parent Xform owners, and separating parametric geometry scale from xform scale during reverse capture.

Resolve material-root connections using exact USD paths, ensure remote parent hierarchy is authored before edited children, and expand unit, real-Blender, and asset coverage for references, payloads, variants, materials, transform round trips, and echo suppression.