### PR TITLE
Fix first-run workflow reliability

### DIFF
--- a/examples/usd_native_client/run.py
+++ b/examples/usd_native_client/run.py
@@ -41,11 +41,19 @@ def _terminate(process: subprocess.Popen | None) -> None:
 
 
 def _remove_log(path: Path) -> None:
-    for suffix in ("", "-wal", "-shm"):
-        try:
-            path.with_name(path.name + suffix).unlink()
-        except OSError:
-            pass
+    pending = [path.with_name(path.name + suffix) for suffix in ("", "-wal", "-shm")]
+    deadline = time.monotonic() + 2.0
+    while pending:
+        remaining = []
+        for candidate in pending:
+            try:
+                candidate.unlink(missing_ok=True)
+            except OSError:
+                remaining.append(candidate)
+        if not remaining or time.monotonic() >= deadline:
+            return
+        pending = remaining
+        time.sleep(0.02)
 
 
 def main() -> int:

--- a/examples/usd_native_client/run.py
+++ b/examples/usd_native_client/run.py
@@ -56,6 +56,16 @@ def _remove_log(path: Path) -> None:
         time.sleep(0.02)
 
 
+def _try_launch_usdview(stage: Path, host: str, port: int) -> subprocess.Popen | None:
+    from integrations.usdview.launcher import launch_usdview
+
+    try:
+        return launch_usdview(str(stage), host=host, port=port)
+    except (OSError, RuntimeError) as exc:
+        print(f"usdview unavailable ({exc}); continuing headless")
+        return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         parents=[demo.build_parser(add_help=False)],
@@ -95,16 +105,7 @@ def main() -> int:
             return 1
 
         if not args.no_usdview:
-            from integrations.usdview.launcher import launch_usdview
-
-            try:
-                usdview = launch_usdview(
-                    str(demo.BASE_USD),
-                    host=args.host,
-                    port=args.port,
-                )
-            except RuntimeError as exc:
-                print(f"usdview unavailable ({exc}); continuing headless")
+            usdview = _try_launch_usdview(demo.BASE_USD, args.host, args.port)
 
         peer = subprocess.Popen(
             [

--- a/integrations/dashboard/pages.py
+++ b/integrations/dashboard/pages.py
@@ -489,7 +489,7 @@ def _build_prim_tree(srv: UsdSyncServer, on_focus=None, register_full_refresh=No
             ui.tree(
                 nodes, node_key="id", label_key="label",
                 on_select=lambda e: _on_select(getattr(e, "value", None)),
-            ).props("dense default-expand-all").classes(
+            ).props("dense").classes(
                 "w-full text-xs font-mono"
             )
 

--- a/integrations/mcp/session.py
+++ b/integrations/mcp/session.py
@@ -103,6 +103,7 @@ class ConnectionSession:
 
         if cfg.mirror_enabled:
             self._start_mirror()
+            self._drain_initial_replay()
         return self.status()
 
     def _start_mirror(self) -> None:
@@ -202,6 +203,16 @@ class ConnectionSession:
                 time.sleep(0.005)
         return self.dispatcher.last_seq >= target_seq
 
+    def _drain_initial_replay(self) -> bool:
+        """Apply the initial replay before returning when it fits the read timeout."""
+        if self.dispatcher is None or self.receiver is None:
+            return False
+        deadline = time.monotonic() + self.config.read_after_write_timeout_s
+        while not self.receiver.synchronized and time.monotonic() < deadline:
+            if self.dispatcher.drain_and_apply() == 0:
+                time.sleep(0.005)
+        return self.receiver.synchronized
+
     def pump(self) -> int:
         """Non-blocking drain so introspection reflects recent foreign edits."""
         if self.dispatcher is None:
@@ -292,6 +303,9 @@ class ConnectionSession:
         )
 
     def status(self) -> dict:
+        if self.dispatcher is not None and self.receiver is not None:
+            if not self.receiver.synchronized:
+                self.pump()
         return {
             "ok": True,
             "connected": self.connected,
@@ -300,6 +314,7 @@ class ConnectionSession:
             "client_id": self.config.client_id,
             "department": self.config.department,
             "mirror_enabled": self.config.mirror_enabled,
+            "mirror_synchronized": bool(self.receiver and self.receiver.synchronized),
             "mirror_prim_count": self._mirror_prim_count(),
             "last_seq": self.dispatcher.last_seq if self.dispatcher else 0,
             "auth_rejected": self.auth_rejected,

--- a/integrations/mcp/session.py
+++ b/integrations/mcp/session.py
@@ -181,6 +181,13 @@ class ConnectionSession:
         """Send one txn and drain the mirror until it reflects the write."""
         if not self.connected:
             raise ToolError("not connected, call usd_connect first", code="not_connected")
+        if self.receiver is not None and not self.receiver.synchronized:
+            if not self._drain_initial_replay():
+                raise ToolError(
+                    "the mirror is still applying the initial replay",
+                    code="mirror_not_ready",
+                    hint="Retry after usd_status reports mirror_synchronized=true.",
+                )
         pre_seq = self.dispatcher.last_seq if self.dispatcher else 0
         if not self.sender.send_events(events):
             self.sender = None

--- a/integrations/usdview/launcher.py
+++ b/integrations/usdview/launcher.py
@@ -302,18 +302,22 @@ def main(argv: list[str] | None = None) -> int:
     )
     args, unknown = parser.parse_known_args(argv)
 
-    proc = launch_usdview(
-        args.stage,
-        host=args.host,
-        port=args.port,
-        token=args.token,
-        extra_args=unknown,
-        usdview_exe=args.usdview,
-        renderman=args.renderman,
-        camera_path=args.camera,
-        expected_seq=args.expected_seq,
-        scene_lights=args.scene_lights,
-    )
+    try:
+        proc = launch_usdview(
+            args.stage,
+            host=args.host,
+            port=args.port,
+            token=args.token,
+            extra_args=unknown,
+            usdview_exe=args.usdview,
+            renderman=args.renderman,
+            camera_path=args.camera,
+            expected_seq=args.expected_seq,
+            scene_lights=args.scene_lights,
+        )
+    except (OSError, RuntimeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
     return proc.wait()
 
 

--- a/openusdconnect/server/state.py
+++ b/openusdconnect/server/state.py
@@ -1885,6 +1885,7 @@ class UsdSyncServer:
         origin: str = "vfs-write",
         reject_stale: bool = True,
         reject_ambiguous: bool = True,
+        unchanged_snapshot: bool = False,
     ) -> int:
         """Replace the live edit state from a complete uploaded USD snapshot.
 
@@ -2047,6 +2048,15 @@ class UsdSyncServer:
                     "uploaded VFS snapshot looks destructively incomplete; "
                     f"removed {len(removed_paths)} of {len(before_paths)} prims"
                 )
+
+            if unchanged_snapshot:
+                analysis = _analysis(
+                    "unchanged",
+                    ["uploaded bytes match the current virtual snapshot"],
+                )
+                self.last_vfs_write_analysis = analysis.to_dict()
+                LOG.info("VFS snapshot write is unchanged; no events generated")
+                return 0
 
             emitter = NoticeEmitter(uploaded_stage)
             try:

--- a/openusdconnect/server/vfs/provider.py
+++ b/openusdconnect/server/vfs/provider.py
@@ -285,11 +285,6 @@ class _CachedVirtualFile:
             try:
                 data = sink.getvalue()
                 self._translate_write(data)
-                LOG.warning(
-                    "VFS write translated (%d bytes) for %s",
-                    sink.bytes_written,
-                    self.name,
-                )
             finally:
                 sink.dispose()
             return
@@ -371,6 +366,7 @@ class VirtualStageFile(_CachedVirtualFile):
         return meta
 
     def _translate_write(self, data: bytes) -> None:
+        matches_current_snapshot = data == self.read()
         try:
             stage = _open_uploaded_stage(data)
         except InvalidVfsWriteError:
@@ -381,13 +377,19 @@ class VirtualStageFile(_CachedVirtualFile):
                 self.name,
             )
             return
-        event_count = self._server.replace_from_stage_snapshot(stage)
-        LOG.warning(
-            "VFS write fallback translated %d bytes from %s into %d events",
-            len(data),
-            self.name,
-            event_count,
+        event_count = self._server.replace_from_stage_snapshot(
+            stage,
+            unchanged_snapshot=matches_current_snapshot,
         )
+        if event_count:
+            LOG.warning(
+                "VFS write fallback translated %d bytes from %s into %d events",
+                len(data),
+                self.name,
+                event_count,
+            )
+        else:
+            LOG.info("VFS write fallback accepted unchanged snapshot for %s", self.name)
 
 
 class _GeneratedTextFile(_CachedVirtualFile):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ vfs = [
     "wsgidav==4.3.3",
 ]
 mcp = [
-    "mcp>=1.2",
+    "mcp>=1.2,<2",
 ]
 profile = [
     "py-spy==0.4.2",

--- a/tests/integration/test_mcp_roundtrip.py
+++ b/tests/integration/test_mcp_roundtrip.py
@@ -124,6 +124,25 @@ def test_ancestors_auto_created_over_the_wire(server):
         session.disconnect()
 
 
+def test_connect_returns_with_existing_replay_applied(server):
+    author = _connect(server)
+    try:
+        result, _prepared = _author(
+            author,
+            [{"k": "ensure_prim", "prim": "/World/Existing", "typeName": "Xform"}],
+        )
+        assert result["mirror_synced"]
+    finally:
+        author.disconnect()
+
+    reader = _connect(server)
+    try:
+        assert reader.status()["mirror_synchronized"] is True
+        assert reader.mirror_stage.GetPrimAtPath("/World/Existing").IsValid()
+    finally:
+        reader.disconnect()
+
+
 def test_changes_since_tracks_own_and_foreign_edits(server):
     session = _connect(server)
     emitter = None

--- a/tests/integration/test_mcp_roundtrip.py
+++ b/tests/integration/test_mcp_roundtrip.py
@@ -13,6 +13,7 @@ from pxr import Usd, UsdGeom
 
 from integrations.mcp import discovery, introspection
 from integrations.mcp.config import McpConfig
+from integrations.mcp.errors import ToolError
 from integrations.mcp.session import ConnectionSession
 from integrations.mcp.validation import validate_and_prepare
 from openusdconnect.adapters import UsdStageAdapter
@@ -139,6 +140,38 @@ def test_connect_returns_with_existing_replay_applied(server):
     try:
         assert reader.status()["mirror_synchronized"] is True
         assert reader.mirror_stage.GetPrimAtPath("/World/Existing").IsValid()
+    finally:
+        reader.disconnect()
+
+
+def test_send_rejects_while_initial_replay_is_incomplete(server):
+    author = ConnectionSession(
+        McpConfig(port=server, client_id="replay-author", read_after_write_timeout_s=10.0)
+    )
+    try:
+        author.connect()
+        events = [{"k": "ensure_prim", "prim": "/World", "typeName": "Xform"}]
+        events.extend(
+            {"k": "ensure_prim", "prim": f"/World/P{index}", "typeName": "Xform"}
+            for index in range(2_000)
+        )
+        assert author.send(events)["mirror_synced"]
+    finally:
+        author.disconnect()
+
+    reader = ConnectionSession(
+        McpConfig(port=server, client_id="replay-reader", read_after_write_timeout_s=0.01)
+    )
+    try:
+        status = reader.connect()
+        assert status["mirror_synchronized"] is False
+
+        with pytest.raises(ToolError) as error:
+            reader.send(
+                [{"k": "ensure_prim", "prim": "/World/TooSoon", "typeName": "Xform"}]
+            )
+
+        assert error.value.code == "mirror_not_ready"
     finally:
         reader.disconnect()
 

--- a/tests/integration/test_usd_client_example.py
+++ b/tests/integration/test_usd_client_example.py
@@ -8,6 +8,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from examples.usd_native_client import run as onboarding
+from integrations.usdview import launcher as usdview_launcher
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -45,3 +48,17 @@ def test_two_peer_usd_client_onboarding_example(tmp_path):
     assert "peer_valid=True" in result.stdout, diagnostic
     assert "peer published /World/PeerCube" in result.stdout, diagnostic
     assert list(tmp_path.glob("usd_native_client_*.db*")) == []
+
+
+def test_usdview_spawn_error_continues_headless(monkeypatch, capsys):
+    def fail_launch(*_args, **_kwargs):
+        raise OSError("usdview executable is not runnable")
+
+    monkeypatch.setattr(usdview_launcher, "launch_usdview", fail_launch)
+
+    process = onboarding._try_launch_usdview(Path("scene.usda"), "127.0.0.1", 7200)
+
+    assert process is None
+    assert capsys.readouterr().out == (
+        "usdview unavailable (usdview executable is not runnable); continuing headless\n"
+    )

--- a/tests/integration/test_usd_client_example.py
+++ b/tests/integration/test_usd_client_example.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import socket
 import subprocess
 import sys
@@ -16,7 +17,8 @@ def _unused_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def test_two_peer_usd_client_onboarding_example():
+def test_two_peer_usd_client_onboarding_example(tmp_path):
+    env = {**os.environ, "TEMP": str(tmp_path), "TMP": str(tmp_path)}
     result = subprocess.run(
         [
             sys.executable,
@@ -34,6 +36,7 @@ def test_two_peer_usd_client_onboarding_example():
         text=True,
         timeout=30,
         check=False,
+        env=env,
     )
 
     diagnostic = f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
@@ -41,3 +44,4 @@ def test_two_peer_usd_client_onboarding_example():
     assert "local_valid=True" in result.stdout, diagnostic
     assert "peer_valid=True" in result.stdout, diagnostic
     assert "peer published /World/PeerCube" in result.stdout, diagnostic
+    assert list(tmp_path.glob("usd_native_client_*.db*")) == []

--- a/tests/unit/test_mcp_session.py
+++ b/tests/unit/test_mcp_session.py
@@ -20,6 +20,8 @@ class _FakeSender:
 
 def _patch_net(monkeypatch, started, stopped):
     class _FakeReceiver:
+        synchronized = True
+
         def start(self):
             started.append(self)
 
@@ -100,3 +102,14 @@ def test_disconnect_stops_receiver(monkeypatch):
     assert receiver in stopped
     assert session.receiver is None
     assert session.sender is None
+
+
+def test_status_reports_mirror_synchronization(monkeypatch):
+    started, stopped = [], []
+    _patch_net(monkeypatch, started, stopped)
+    session = session_mod.ConnectionSession(McpConfig())
+
+    status = session.connect()
+
+    assert status["mirror_synchronized"] is True
+    session.disconnect()

--- a/tests/unit/test_usdview_launcher.py
+++ b/tests/unit/test_usdview_launcher.py
@@ -151,3 +151,16 @@ def test_main_accepts_presentation_arguments(monkeypatch):
     assert captured["camera_path"] == "/World/_TestCam"
     assert captured["expected_seq"] == 262
     assert captured["scene_lights"] is True
+
+
+def test_main_reports_discovery_error_without_traceback(monkeypatch, capsys):
+    monkeypatch.setattr(
+        launcher,
+        "launch_usdview",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("usdview unavailable")),
+    )
+
+    assert launcher.main(["test_scene.usda"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "error: usdview unavailable\n"

--- a/tests/unit/test_vfs.py
+++ b/tests/unit/test_vfs.py
@@ -468,6 +468,18 @@ class TestWriteDrop:
 
 
 class TestWriteTranslate:
+    def test_writing_current_snapshot_is_noop(self, srv, translate_vfile):
+        before = translate_vfile.read()
+        before_count = srv.get_event_count()
+        before_token = srv.get_snapshot_token()
+
+        translate_vfile.write(before)
+
+        assert srv.get_event_count() == before_count
+        assert srv.get_snapshot_token() == before_token
+        assert translate_vfile.read() == before
+        assert srv.last_vfs_write_analysis["status"] == "unchanged"
+
     def test_write_replaces_live_state_with_uploaded_snapshot(self, srv, translate_vfile):
         _send(
             srv,

--- a/uv.lock
+++ b/uv.lock
@@ -1048,7 +1048,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "ruff", specifier = "==0.15.6" },
 ]
-mcp = [{ name = "mcp", specifier = ">=1.2" }]
+mcp = [{ name = "mcp", specifier = ">=1.2,<2" }]
 profile = [{ name = "py-spy", specifier = "==0.4.2" }]
 vfs = [
     { name = "cheroot", specifier = "==10.0.1" },


### PR DESCRIPTION
## Summary
- Apply MCP initial replay before reporting a synchronized mirror.
- Treat unchanged VFS snapshot writes as a no-op.
- Improve usdview startup errors, Windows example cleanup, and large dashboard tree behavior.
- Constrain the MCP SDK to the supported major version.

## Testing
- `uv run ruff check examples/usd_native_client/run.py integrations/dashboard/pages.py integrations/mcp/session.py integrations/usdview/launcher.py openusdconnect/server/state.py openusdconnect/server/vfs/provider.py tests/integration/test_mcp_roundtrip.py tests/integration/test_usd_client_example.py tests/unit/test_mcp_session.py tests/unit/test_usdview_launcher.py tests/unit/test_vfs.py`
- Focused tests: 73 passed
- Full unit suite: 1659 passed, 48 skipped
