### PR TITLE
Centralize release versioning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 # never committed.
 tests/visual/references/**/*.png filter=lfs diff=lfs merge=lfs -text
 tests/visual/references/**/*.exr filter=lfs diff=lfs merge=lfs -text
+
+# Shell scripts must remain executable from WSL and Unix checkouts.
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG DASHBOARD=0
 WORKDIR /app
 
 # Install the package, bundled OpenUSD runtime, and VFS dependencies.
-COPY pyproject.toml README.md LICENSE ./
+COPY pyproject.toml README.md LICENSE NOTICE ./
 COPY openusdconnect/ openusdconnect/
 COPY native/sdf_notice_bridge/ native/sdf_notice_bridge/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /app
 # Install the package, bundled OpenUSD runtime, and VFS dependencies.
 COPY pyproject.toml README.md LICENSE ./
 COPY openusdconnect/ openusdconnect/
+COPY native/sdf_notice_bridge/ native/sdf_notice_bridge/
 
 RUN pip install --no-cache-dir . \
     && pip install --no-cache-dir usd-core==26.8 wsgidav==4.3.3 cheroot==10.0.1

--- a/integrations/blender/__init__.py
+++ b/integrations/blender/__init__.py
@@ -7,7 +7,7 @@ The zip bundles the openusdconnect core library inside the addon directory.
 bl_info = {
     "name": "USD Connect",
     "author": "OpenUSDConnect",
-    "version": (0, 1, 0),
+    "version": (0, 2, 0),
     "blender": (4, 4, 0),
     "location": "View3D > Sidebar > USD Connect",
     "description": "Real-time USD sync: capture and receive transform edits over the network",

--- a/integrations/dashboard/pages.py
+++ b/integrations/dashboard/pages.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from nicegui import ui
 
+from openusdconnect._version import __version__
 from openusdconnect.protocol_constants import EVENT_KEYS
 from openusdconnect.server.types import ReplayModeConflictError
 
@@ -141,6 +142,7 @@ def setup_pages(srv: UsdSyncServer):
             ui.label("OpenUSDConnect Dashboard").classes(
                 "text-lg font-semibold dash-accent"
             )
+            ui.label(f"v{__version__}").classes("text-xs dash-muted")
             ui.space()
             ui.select(
                 {0: "Off", 2: "2s", 5: "5s", 10: "10s", 30: "30s"},

--- a/integrations/unreal/OpenUSDConnect/OpenUSDConnect.uplugin
+++ b/integrations/unreal/OpenUSDConnect/OpenUSDConnect.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0",
+	"VersionName": "1.0.0",
 	"FriendlyName": "OpenUSD Connect",
 	"Description": "Live sync of a USD stage between DCC tools and Unreal Engine via the OpenUSDConnect server.",
 	"Category": "Pipeline",

--- a/openusdconnect/__init__.py
+++ b/openusdconnect/__init__.py
@@ -4,6 +4,7 @@ Core library for replicating USD stage edits over a networked event protocol.
 """
 
 from ._runtime import select_runtime as _select_runtime
+from ._version import __version__
 
 _select_runtime()
 del _select_runtime
@@ -55,8 +56,6 @@ from .shared_stage_client import (
     SharedStageClient,
 )
 from .usd_client import UsdPublisher, UsdReceiver
-
-__version__ = "0.1.0"
 
 __all__ = [
     "DCCAdapter",

--- a/openusdconnect/_version.py
+++ b/openusdconnect/_version.py
@@ -1,0 +1,3 @@
+"""Canonical OpenUSDConnect release version."""
+
+__version__ = "0.2.0"

--- a/openusdconnect/build_sdf_notice_bridge.py
+++ b/openusdconnect/build_sdf_notice_bridge.py
@@ -8,6 +8,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .cli_common import add_version_argument
+
 
 def _source_directory() -> Path:
     package = Path(__file__).resolve().parent
@@ -96,6 +98,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Build the Sdf notice bridge against this process's OpenUSD install.",
     )
+    add_version_argument(parser)
     parser.add_argument(
         "--pxr-dir",
         type=Path,

--- a/openusdconnect/cli_common.py
+++ b/openusdconnect/cli_common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 
+from ._version import __version__
 from .defaults import (
     DEFAULT_HOST,
     DEFAULT_SYNC_PORT,
@@ -11,6 +12,12 @@ from .defaults import (
     DEFAULT_VFS_PORT,
     DEFAULT_VFS_SHARE,
 )
+
+
+def add_version_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the standard OpenUSDConnect release-version flag."""
+
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
 
 
 def validate_port(value: str | int) -> int:

--- a/openusdconnect/send.py
+++ b/openusdconnect/send.py
@@ -30,7 +30,7 @@ import argparse
 import json
 import sys
 
-from .cli_common import add_sync_endpoint_args
+from .cli_common import add_sync_endpoint_args, add_version_argument
 from .sender import EventSender
 
 
@@ -48,6 +48,7 @@ def main(argv: list[str] | None = None):
         prog="openusdconnect-send",
         description="Send events to a running OpenUSDConnect server.",
     )
+    add_version_argument(parser)
     parser.add_argument(
         "events",
         nargs="*",

--- a/openusdconnect/server/cli.py
+++ b/openusdconnect/server/cli.py
@@ -17,8 +17,10 @@ from dataclasses import dataclass
 import pxr
 from pxr import Ar, Usd
 
+from .._version import __version__
 from ..cli_common import (
     add_sync_endpoint_args,
+    add_version_argument,
     add_vfs_resource_args,
     comma_separated,
     file_name,
@@ -31,6 +33,7 @@ from ..cli_common import (
     validate_file_name,
     validate_path_segment,
 )
+from ..codec import SCHEMA_VERSION
 from ..defaults import (
     DEFAULT_EVENT_LOG,
     DEFAULT_HOST,
@@ -52,7 +55,7 @@ from ..plugin_environment import (
     PluginEnvironmentError,
     prepare_usd_plugin_environment,
 )
-from ..protocol_constants import LayerMode
+from ..protocol_constants import PROTOCOL_VERSION, LayerMode
 from .connection import ConnectionHandler, ThreadedTCPServer
 from .state import UsdSyncServer
 
@@ -63,6 +66,15 @@ def _log_usd_runtime() -> None:
     version = ".".join(str(part) for part in Usd.GetVersion())
     bindings = getattr(pxr, "__file__", None) or "unknown"
     LOG.info("OpenUSD runtime: %s; bindings: %s", version, bindings)
+
+
+def _log_openusdconnect_version() -> None:
+    LOG.info(
+        "OpenUSDConnect %s; protocol %d; schema %d",
+        __version__,
+        PROTOCOL_VERSION,
+        SCHEMA_VERSION,
+    )
 
 
 @dataclass(slots=True)
@@ -146,6 +158,7 @@ def _create_resolver_context(values: list[str] | None) -> Ar.ResolverContext | N
 def run_server(config: ServerConfig | None = None):
     """Start the server (blocking)."""
     config = config or ServerConfig()
+    _log_openusdconnect_version()
     _log_usd_runtime()
     layer_mode = LayerMode(config.layer_mode)
     if layer_mode is LayerMode.SHARED_STAGE and config.vfs is not None:
@@ -318,6 +331,7 @@ def main(argv: list[str] | None = None) -> int:
         description="OpenUSDConnect sync server",
         allow_abbrev=False,
     )
+    add_version_argument(ap)
     endpoint = ap.add_argument_group("sync endpoint")
     add_sync_endpoint_args(endpoint)
 

--- a/openusdconnect/vfs_mount.py
+++ b/openusdconnect/vfs_mount.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Literal
 
-from .cli_common import add_vfs_resource_args
+from .cli_common import add_version_argument, add_vfs_resource_args
 from .defaults import host_for_url
 
 
@@ -347,6 +347,7 @@ def _print_macos_paths(config: MacOSMountConfig) -> None:
 
 def _build_native_parser(backend: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    add_version_argument(parser)
     parser.add_argument("action", nargs="?", choices=["mount", "unmount"], default="mount")
     endpoint = parser.add_argument_group("virtual file service")
     add_vfs_resource_args(endpoint, option_prefix="")
@@ -502,12 +503,18 @@ def _mount_native(config: NativeMountConfig) -> MountedLocation:
 
 
 def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if "--version" in arguments:
+        version_parser = argparse.ArgumentParser(add_help=False)
+        add_version_argument(version_parser)
+        version_parser.parse_args(["--version"])
+
     try:
         backend = native_backend()
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
         return 2
-    config = _parse_native_config(backend, argv)
+    config = _parse_native_config(backend, arguments)
     common = config.common
 
     if common.print_only:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = [
 
 [project]
 name = "openusdconnect"
-version = "0.1.0"
+dynamic = ["version"]
 description = "General-purpose real-time USD sync framework for DCC livelink"
 readme = "README.md"
 license = "Apache-2.0"
@@ -31,6 +31,9 @@ dependencies = [
     "flatbuffers==25.12.19",
     "numpy==2.4.4",
 ]
+
+[tool.hatch.version]
+path = "openusdconnect/_version.py"
 
 [project.urls]
 Repository = "https://github.com/RoboticHuman/OpenUSDConnect"

--- a/scripts/build_blender_addon.py
+++ b/scripts/build_blender_addon.py
@@ -10,7 +10,9 @@ Output:
     dist/usd_connect_blender.zip
 """
 
+import ast
 import os
+import runpy
 import shutil
 import zipfile
 from pathlib import Path
@@ -21,7 +23,39 @@ ADDON_NAME = "usd_connect"
 ZIP_NAME = "usd_connect_blender.zip"
 
 
+def _project_version() -> str:
+    namespace = runpy.run_path(REPO_ROOT / "openusdconnect" / "_version.py")
+    return str(namespace["__version__"])
+
+
+def _blender_version(path: Path) -> tuple[int, int, int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "bl_info" for target in node.targets
+        ):
+            value = ast.literal_eval(node.value)
+            return tuple(value["version"])
+    raise RuntimeError(f"bl_info not found in {path}")
+
+
+def _validate_version() -> None:
+    version = _project_version()
+    try:
+        expected = tuple(int(part) for part in version.split("."))
+    except ValueError as exc:
+        raise RuntimeError(f"Blender packaging requires an X.Y.Z release version, got {version}") from exc
+    addon_path = REPO_ROOT / "integrations" / "blender" / "__init__.py"
+    actual = _blender_version(addon_path)
+    if actual != expected:
+        raise RuntimeError(
+            f"Blender addon version {actual} does not match OpenUSDConnect {version}"
+        )
+
+
 def build():
+    _validate_version()
+
     # Clean
     build_dir = REPO_ROOT / "build" / ADDON_NAME
     if build_dir.exists():

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,208 @@
+"""Check release, compatibility, protocol, and toolchain version declarations."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import runpy
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _assignment(path: str, name: str):
+    tree = ast.parse(_read(path), filename=path)
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if any(isinstance(target, ast.Name) and target.id == name for target in targets):
+                return ast.literal_eval(node.value)
+    raise ValueError(f"{name} not found in {path}")
+
+
+def _blender_info() -> dict:
+    return _assignment("integrations/blender/__init__.py", "bl_info")
+
+
+def _dependency_pin(pyproject: dict, group: str, package: str) -> str | None:
+    dependencies = (
+        pyproject["project"]["dependencies"]
+        if group == "project"
+        else pyproject["dependency-groups"][group]
+    )
+    prefix = f"{package}=="
+    matches = [item[len(prefix) :] for item in dependencies if item.lower().startswith(prefix)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _generated_flatbuffers_version() -> str | None:
+    header = _read(
+        "integrations/unreal/OpenUSDConnect/Source/OpenUSDConnectPXR/Public/Schema/"
+        "messages_generated.h"
+    )
+    parts = []
+    for field in ("MAJOR", "MINOR", "REVISION"):
+        match = re.search(rf"FLATBUFFERS_VERSION_{field}\s*==\s*(\d+)", header)
+        if not match:
+            return None
+        parts.append(match.group(1))
+    return ".".join(parts)
+
+
+def _docker_instructions(dockerfile: str) -> list[str]:
+    instructions: list[str] = []
+    current = ""
+    for raw_line in dockerfile.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        continued = line.endswith("\\")
+        line = line.removesuffix("\\").rstrip()
+        current = f"{current} {line}".strip()
+        if not continued:
+            instructions.append(current)
+            current = ""
+    if current:
+        instructions.append(current)
+    return instructions
+
+
+def _docker_pip_pins(dockerfile: str) -> dict[str, str]:
+    pins: dict[str, str] = {}
+    for instruction in _docker_instructions(dockerfile):
+        for command in re.findall(r"\bpip\s+install\b(.*?)(?=\s*(?:&&|;|$))", instruction):
+            for package, version in re.findall(
+                r"(?<![\w.-])([A-Za-z0-9_.-]+)==([A-Za-z0-9_.+-]+)", command
+            ):
+                pins[package.lower()] = version
+    return pins
+
+
+def _docker_base_images(dockerfile: str) -> list[str]:
+    images = []
+    for instruction in _docker_instructions(dockerfile):
+        match = re.fullmatch(r"FROM\s+(?:--platform=\S+\s+)?(\S+)(?:\s+AS\s+\S+)?", instruction, re.I)
+        if match:
+            images.append(match.group(1))
+    return images
+
+
+def _cpp_constant(name: str) -> int | None:
+    header = _read(
+        "integrations/unreal/OpenUSDConnect/Source/OpenUSDConnectPXR/Public/"
+        "USDConnectProtocol.h"
+    )
+    match = re.search(rf"{name}\s*=\s*(\d+)", header)
+    return int(match.group(1)) if match else None
+
+
+def collect_errors() -> list[str]:
+    errors: list[str] = []
+    pyproject = tomllib.loads(_read("pyproject.toml"))
+    release = str(runpy.run_path(ROOT / "openusdconnect" / "_version.py")["__version__"])
+
+    if not SEMVER.fullmatch(release):
+        errors.append(f"OpenUSDConnect release must use X.Y.Z SemVer, got {release!r}")
+    if pyproject["project"].get("dynamic") != ["version"]:
+        errors.append("pyproject project.version must be dynamic")
+    if pyproject.get("tool", {}).get("hatch", {}).get("version", {}).get("path") != (
+        "openusdconnect/_version.py"
+    ):
+        errors.append("Hatch must read the release from openusdconnect/_version.py")
+    blender = _blender_info()
+    blender_release = ".".join(str(part) for part in blender["version"])
+    if blender_release != release:
+        errors.append(f"Blender addon {blender_release} must match core release {release}")
+
+    unreal_path = "integrations/unreal/OpenUSDConnect/OpenUSDConnect.uplugin"
+    unreal = json.loads(_read(unreal_path))
+    if not isinstance(unreal.get("Version"), int) or unreal["Version"] < 1:
+        errors.append("Unreal plugin Version must be a positive build integer")
+    if not SEMVER.fullmatch(str(unreal.get("VersionName", ""))):
+        errors.append("Unreal plugin VersionName must use X.Y.Z SemVer")
+
+    protocol = int(_assignment("openusdconnect/protocol_constants.py", "PROTOCOL_VERSION"))
+    schema = int(_assignment("openusdconnect/codec.py", "SCHEMA_VERSION"))
+    if _cpp_constant("kProtocolVersion") != protocol:
+        errors.append("Unreal kProtocolVersion does not match Python PROTOCOL_VERSION")
+    if _cpp_constant("kSchemaVersion") != schema:
+        errors.append("Unreal kSchemaVersion does not match Python SCHEMA_VERSION")
+
+    flatbuffers = _dependency_pin(pyproject, "project", "flatbuffers")
+    setup_flatbuffers = str(
+        _assignment("integrations/unreal/OpenUSDConnect/setup_flatbuffers.py", "DEFAULT_VERSION")
+    )
+    generated_flatbuffers = _generated_flatbuffers_version()
+    if not flatbuffers or flatbuffers != setup_flatbuffers or flatbuffers != generated_flatbuffers:
+        errors.append(
+            "FlatBuffers Python, Unreal setup, and generated-header versions must match"
+        )
+    vendored_version = ROOT / (
+        "integrations/unreal/OpenUSDConnect/Source/OpenUSDConnectPXR/ThirdParty/"
+        "flatbuffers/VERSION"
+    )
+    if vendored_version.is_file() and vendored_version.read_text(encoding="utf-8").strip() != flatbuffers:
+        errors.append("Vendored Unreal FlatBuffers headers do not match the configured version")
+
+    python_minor = _read(".python-version").strip()
+    if pyproject["project"]["requires-python"] != f">={python_minor}":
+        errors.append(".python-version and project.requires-python must match")
+    if pyproject["tool"]["ruff"]["target-version"] != f"py{python_minor.replace('.', '')}":
+        errors.append(".python-version and Ruff target-version must match")
+    docker = _read("Dockerfile")
+    if f"python:{python_minor}-slim" not in _docker_base_images(docker):
+        errors.append("Docker Python image must match .python-version")
+
+    docker_pins = _docker_pip_pins(docker)
+    for group, package in (
+        ("bundled-usd", "usd-core"),
+        ("vfs", "wsgidav"),
+        ("vfs", "cheroot"),
+        ("dashboard", "nicegui"),
+    ):
+        expected = _dependency_pin(pyproject, group, package)
+        if not expected or docker_pins.get(package) != expected:
+            errors.append(f"Docker {package} pin must match pyproject dependency group {group}")
+
+    return errors
+
+
+def version_summary() -> list[str]:
+    pyproject = tomllib.loads(_read("pyproject.toml"))
+    release = str(runpy.run_path(ROOT / "openusdconnect" / "_version.py")["__version__"])
+    unreal = json.loads(_read("integrations/unreal/OpenUSDConnect/OpenUSDConnect.uplugin"))
+    return [
+        f"OpenUSDConnect / Blender: {release}",
+        f"Unreal plugin: {unreal['VersionName']} (build {unreal['Version']})",
+        f"Protocol: {_assignment('openusdconnect/protocol_constants.py', 'PROTOCOL_VERSION')}",
+        f"Wire schema: {_assignment('openusdconnect/codec.py', 'SCHEMA_VERSION')}",
+        f"FlatBuffers: {_dependency_pin(pyproject, 'project', 'flatbuffers')}",
+        f"Python: {pyproject['project']['requires-python']}",
+        f"Blender: >={'.'.join(str(part) for part in _blender_info()['blender'])}",
+        f"Unreal Engine: {unreal['EngineVersion']}",
+        f"Bundled OpenUSD: {_dependency_pin(pyproject, 'bundled-usd', 'usd-core')}",
+    ]
+
+
+def main() -> int:
+    errors = collect_errors()
+    for line in version_summary():
+        print(line)
+    if errors:
+        print("\nVersion consistency errors:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("\nAll version declarations are consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_flatbuffers.sh
+++ b/scripts/generate_flatbuffers.sh
@@ -10,6 +10,35 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 SCHEMA_DIR="$ROOT/openusdconnect/schema"
 OUT_DIR="$ROOT/openusdconnect/generated"
 
+if command -v uv >/dev/null 2>&1; then
+    PYTHON=(uv run python)
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON=(python3)
+elif command -v python >/dev/null 2>&1; then
+    PYTHON=(python)
+else
+    echo "error: Python 3 is required to read the FlatBuffers pin" >&2
+    exit 1
+fi
+
+EXPECTED_FLATBUFFERS_VERSION="$("${PYTHON[@]}" - "$ROOT/pyproject.toml" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as stream:
+    dependencies = tomllib.load(stream)["project"]["dependencies"]
+pins = [item.split("==", 1)[1] for item in dependencies if item.startswith("flatbuffers==")]
+if len(pins) != 1:
+    raise SystemExit("pyproject.toml must contain one exact flatbuffers pin")
+print(pins[0])
+PY
+)"
+ACTUAL_FLATBUFFERS_VERSION="$(flatc --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)"
+if [[ "$ACTUAL_FLATBUFFERS_VERSION" != "$EXPECTED_FLATBUFFERS_VERSION" ]]; then
+    echo "error: flatc $EXPECTED_FLATBUFFERS_VERSION is required; found $ACTUAL_FLATBUFFERS_VERSION" >&2
+    exit 1
+fi
+
 # Python single file, all types in one module
 rm -f "$OUT_DIR/messages_generated.py"
 rm -rf "$OUT_DIR/OpenUSDConnect"
@@ -22,9 +51,7 @@ flatc --python --gen-all --gen-onefile \
 echo "Python bindings generated: $OUT_DIR/messages_generated.py"
 
 # Unreal C++ bindings one self-contained header, committed alongside the
-# plugin. The generated code pins the flatc runtime version (static_assert);
-# keep setup_flatbuffers.py's DEFAULT_VERSION in lockstep with the flatc
-# used here.
+# plugin. The generated code pins the flatc runtime version (static_assert).
 UE_SCHEMA_DIR="$ROOT/integrations/unreal/OpenUSDConnect/Source/OpenUSDConnectPXR/Public/Schema"
 flatc --cpp --gen-all --cpp-std c++17 \
     -I "$SCHEMA_DIR" \

--- a/tests/integration/asset_tests/run_all.sh
+++ b/tests/integration/asset_tests/run_all.sh
@@ -1,41 +1,7 @@
-#!/bin/bash
-# Run all asset integration tests sequentially.
-# Requires: uv, Blender at .blender/blender-5.0.1-windows-x64/blender.exe
-# Usage: bash tests/integration/asset_tests/run_all.sh
+#!/usr/bin/env bash
+# Run the maintained asset integration suite. Extra arguments pass to pytest.
 
-set -e
+set -euo pipefail
 cd "$(dirname "$0")/../../.."
 
-BLENDER=".blender/blender-5.0.1-windows-x64/blender.exe"
-PORT=7202
-DB="test_asset_suite.db"
-RESULTS=""
-
-for test in tests/integration/asset_tests/test_*.py; do
-    name=$(basename "$test" .py)
-    echo ""
-    echo "====== Running: $name ======"
-
-    # Clean and start server
-    rm -f "$DB"*
-    uv run python -m openusdconnect.server --host 127.0.0.1 --port $PORT --log "$DB" &
-    SERVER_PID=$!
-    sleep 3
-
-    # Run test
-    BLENDER_USER_RESOURCES=".blender/user_data" \
-        "$BLENDER" --python "$test" 2>&1 | tee "/tmp/$name.log"
-
-    # Extract result
-    result=$(grep -E "SUCCESS|FAILED" "/tmp/$name.log" | tail -1)
-    RESULTS="$RESULTS\n  $name: $result"
-
-    # Kill server
-    kill $SERVER_PID 2>/dev/null || true
-    wait $SERVER_PID 2>/dev/null || true
-    rm -f "$DB"*
-done
-
-echo ""
-echo "====== SUMMARY ======"
-echo -e "$RESULTS"
+uv run pytest tests/integration/asset_tests/ --asset-tests -v "$@"

--- a/tests/unit/test_bundled_usd_runtime.py
+++ b/tests/unit/test_bundled_usd_runtime.py
@@ -101,4 +101,5 @@ def test_docker_uses_bundled_usd_pin():
 
     assert bundled_dependencies == ["usd-core==26.8"]
     assert f"pip install --no-cache-dir {bundled_dependencies[0]}" in dockerfile
+    assert "COPY pyproject.toml README.md LICENSE NOTICE ./" in dockerfile
     assert "COPY native/sdf_notice_bridge/ native/sdf_notice_bridge/" in dockerfile

--- a/tests/unit/test_bundled_usd_runtime.py
+++ b/tests/unit/test_bundled_usd_runtime.py
@@ -101,3 +101,4 @@ def test_docker_uses_bundled_usd_pin():
 
     assert bundled_dependencies == ["usd-core==26.8"]
     assert f"pip install --no-cache-dir {bundled_dependencies[0]}" in dockerfile
+    assert "COPY native/sdf_notice_bridge/ native/sdf_notice_bridge/" in dockerfile

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -1,0 +1,41 @@
+"""Repository-wide version source and mirror checks."""
+
+import argparse
+import importlib.metadata
+
+import pytest
+
+from openusdconnect import __version__
+from openusdconnect.cli_common import add_version_argument
+from scripts.check_versions import _docker_base_images, _docker_pip_pins, collect_errors
+
+
+def test_version_declarations_are_consistent():
+    assert collect_errors() == []
+
+
+def test_installed_distribution_uses_canonical_version():
+    assert importlib.metadata.version("openusdconnect") == __version__
+
+
+def test_standard_cli_version_output(capsys):
+    parser = argparse.ArgumentParser(prog="openusdconnect-tool")
+    add_version_argument(parser)
+
+    with pytest.raises(SystemExit) as error:
+        parser.parse_args(["--version"])
+
+    assert error.value.code == 0
+    assert capsys.readouterr().out == f"openusdconnect-tool {__version__}\n"
+
+
+def test_docker_version_parser_ignores_comments_and_stale_active_pins():
+    dockerfile = """\
+    # FROM python:3.13-slim
+    FROM python:3.12-slim AS base
+    # usd-core==26.8
+    RUN pip install --no-cache-dir usd-core==26.7
+    """
+
+    assert _docker_base_images(dockerfile) == ["python:3.12-slim"]
+    assert _docker_pip_pins(dockerfile) == {"usd-core": "26.7"}

--- a/tests/unit/test_vfs_mount.py
+++ b/tests/unit/test_vfs_mount.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from openusdconnect import vfs_mount
+from openusdconnect import __version__, vfs_mount
 
 
 def test_default_unc():
@@ -28,6 +28,19 @@ def test_native_backend_selection():
     assert vfs_mount.native_backend("Darwin") == "macos"
     with pytest.raises(RuntimeError, match="local_vfs_bridge.py"):
         vfs_mount.native_backend("Linux")
+
+
+def test_version_does_not_require_a_supported_mount_backend(monkeypatch, capsys):
+    def fail_backend_detection():
+        raise AssertionError("backend detection should not run")
+
+    monkeypatch.setattr(vfs_mount, "native_backend", fail_backend_detection)
+
+    with pytest.raises(SystemExit) as error:
+        vfs_mount.main(["--version"])
+
+    assert error.value.code == 0
+    assert capsys.readouterr().out.endswith(f" {__version__}\n")
 
 
 def test_default_macos_mount_point(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -999,7 +999,6 @@ wheels = [
 
 [[package]]
 name = "openusdconnect"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- Add one source of truth for the Python package and Blender add-on version.
- Normalize Unreal's independent plugin version and preserve its build counter.
- Add CLI and dashboard version reporting plus repository consistency checks.
- Keep FlatBuffers generation, packaging pins, and bundled runtime declarations consistent.

## Testing
- `uv lock --check`
- `uv run ruff check .`
- `uv run python scripts/check_versions.py`
- Focused versioning tests: 28 passed
- Full unit suite: 1679 passed, 30 skipped
