### PR TITLE
feat(setup): add cross-platform OpenUSD runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ OpenUSD was built against.
 The launchers search the install prefix for current Windows
 `Lib/site-packages`, Unix `lib/pythonX.Y/site-packages` or `dist-packages`, and
 legacy `lib/python` layouts. Activate the matching venv first when necessary;
-bindings installed outside the prefix require `-PythonPath` or `--python-path`.
+its site-packages is also searched. Use `-PythonPath` or `--python-path` only
+when the bindings are in another location.
 
 Configure the current PowerShell session on Windows:
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,27 @@ git clone https://github.com/RoboticHuman/OpenUSDConnect.git
 cd OpenUSDConnect
 ```
 
-Activate the build for the current PowerShell terminal, then install the base
-library without the `bundled-usd` group:
+The active interpreter must use the same Python major/minor version that
+OpenUSD was built against.
+The launchers search the install prefix for current Windows
+`Lib/site-packages`, Unix `lib/pythonX.Y/site-packages` or `dist-packages`, and
+legacy `lib/python` layouts. Activate the matching venv first when necessary;
+bindings installed outside the prefix require `-PythonPath` or `--python-path`.
+
+Configure the current PowerShell session on Windows:
 
 ```powershell
-.\scripts\openusd_env.ps1 "C:\path\to\OpenUSDInstall"
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall"
 uv sync
 ```
 
-Pass `-RenderManRoot`, `-PluginPath`, or `-DllDir` when the project needs them.
-For automation or other shells, wrap individual commands instead:
+Or configure the current Bash/Zsh session on Linux or macOS:
+
+```bash
+source scripts/openusd_env.sh /opt/OpenUSDInstall
+```
+
+For automation or CI, configure only the child command:
 
 ```bash
 uv run python scripts/run_with_openusd.py --usd-root /path/to/OpenUSD -- \
@@ -58,9 +69,9 @@ uv run python scripts/run_with_openusd.py --usd-root /path/to/OpenUSD -- \
 ```
 
 The [CLI reference](docs/cli-reference.md#openusd-runtime-and-custom-plugins)
-covers plugin paths, native libraries, renderer setup, and verification.
-Commands below assume that runtime remains active; wrapper users place the
-shown command after `--`.
+covers venv layouts, external bindings, interpreter selection, plugin and DLL
+paths, RenderMan, verification, and every launcher option. Commands below
+assume that runtime remains active; wrapper users place them after `--`.
 
 ### Verify synchronization locally
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -112,29 +112,24 @@ leading dot and space dot-source the script; nothing is changed persistently:
 uv run --isolated openusdconnect-server --base scene.usda
 ```
 
-The first positional argument is the OpenUSD install prefix. The script checks
-the current OpenUSD Python install layouts (`Lib/site-packages` on Windows and
-`lib/pythonX.Y/site-packages` on Unix), `dist-packages`, and the legacy
-`lib/python` layout.
+The first positional argument is the OpenUSD install prefix. Binding discovery
+checks `Lib/site-packages` on Windows, `lib/pythonX.Y/site-packages` and
+`dist-packages` on Unix, the legacy `lib/python` layout, and the active venv's
+site-packages. Install-prefix locations take precedence over the active venv.
 
-There are two distinct virtual-environment cases:
-
-1. If the venv itself was `CMAKE_INSTALL_PREFIX`, activate it and pass the venv
-   directory as `UsdRoot`. Its bindings are found automatically.
-2. If OpenUSD has a separate native prefix and `PXR_PYTHON_INSTALL_DIR` points
-   into a venv, activate that venv, pass the native prefix as `UsdRoot`, and
-   provide its site-packages directory explicitly.
+If OpenUSD's bindings were installed into a venv, activate it before running
+the launcher. This works whether the venv itself is the native install prefix
+or `PXR_PYTHON_INSTALL_DIR` points into a venv outside the native prefix:
 
 ```powershell
 & "D:\OpenUSD\.venv\Scripts\Activate.ps1"
-. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall" `
-    -PythonPath "D:\OpenUSD\.venv\Lib\site-packages"
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall"
 ```
 
-In either case, the active interpreter must match the Python version against
-which OpenUSD was built. Activating the venv also ensures generated commands
-such as `usdview.cmd` resolve that interpreter from `PATH`. Alternatively, pass
-`-PythonExecutable "D:\OpenUSD\.venv\Scripts\python.exe"`.
+The active interpreter must match the Python version against which OpenUSD was
+built. Activating the venv also ensures generated commands such as
+`usdview.cmd` resolve that interpreter from `PATH`. Pass `-PythonPath` only if
+the bindings are neither under the install prefix nor in the active venv.
 
 A valid `RMANTREE` already present in the process is configured automatically.
 Use `-RenderManRoot` to select or override it, and pass arrays to `-PluginPath`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,17 +103,64 @@ Use the same compatible OpenUSD build and plugin environment as the clients in
 your project. This is the primary path and is required for MaterialX, custom
 renderers, resolvers, file formats, and shader definitions.
 
-From the repository root, activate the selected install for the current
-PowerShell terminal, then run without enabling the `bundled-usd` group:
+From the repository root, configure the selected install for the current
+PowerShell process, then run without enabling the `bundled-usd` group. The
+leading dot and space dot-source the script; nothing is changed persistently:
 
 ```powershell
-.\scripts\openusd_env.ps1 "C:\path\to\OpenUSDInstall"
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall"
 uv run --isolated openusdconnect-server --base scene.usda
 ```
 
-The first positional argument is the OpenUSD install directory containing
-`bin` and `lib`. Use `-RenderManRoot` for hdPrman and pass arrays to
-`-PluginPath` or `-DllDir` for project additions.
+The first positional argument is the OpenUSD install prefix. The script checks
+the current OpenUSD Python install layouts (`Lib/site-packages` on Windows and
+`lib/pythonX.Y/site-packages` on Unix), `dist-packages`, and the legacy
+`lib/python` layout.
+
+There are two distinct virtual-environment cases:
+
+1. If the venv itself was `CMAKE_INSTALL_PREFIX`, activate it and pass the venv
+   directory as `UsdRoot`. Its bindings are found automatically.
+2. If OpenUSD has a separate native prefix and `PXR_PYTHON_INSTALL_DIR` points
+   into a venv, activate that venv, pass the native prefix as `UsdRoot`, and
+   provide its site-packages directory explicitly.
+
+```powershell
+& "D:\OpenUSD\.venv\Scripts\Activate.ps1"
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall" `
+    -PythonPath "D:\OpenUSD\.venv\Lib\site-packages"
+```
+
+In either case, the active interpreter must match the Python version against
+which OpenUSD was built. Activating the venv also ensures generated commands
+such as `usdview.cmd` resolve that interpreter from `PATH`. Alternatively, pass
+`-PythonExecutable "D:\OpenUSD\.venv\Scripts\python.exe"`.
+
+A valid `RMANTREE` already present in the process is configured automatically.
+Use `-RenderManRoot` to select or override it, and pass arrays to `-PluginPath`
+or `-DllDir` for project additions.
+
+For example, configure hdPrman explicitly and launch usdview:
+
+```powershell
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall" `
+    -RenderManRoot "C:\Program Files\Pixar\RenderManProServer-27.3"
+usdview scene.usda --renderer HdPrmanLoaderRendererPlugin
+```
+
+For an interactive Bash or Zsh session, source the Unix adapter. Its options
+use the same long names as the command wrapper:
+
+```bash
+source /opt/OpenUSD/.venv/bin/activate
+source scripts/openusd_env.sh /opt/OpenUSDInstall \
+  --python-path /opt/OpenUSD/.venv/lib/python3.13/site-packages \
+  --renderman-root /opt/pixar/RenderManProServer-27.3
+```
+
+Both activation scripts delegate discovery and path construction to
+`openusd_runtime.py`; the adapters only apply its environment delta to their
+current shell.
 
 For automation or other shells, configure one command through the
 cross-platform wrapper:
@@ -123,11 +170,16 @@ uv run python scripts/run_with_openusd.py --usd-root /path/to/OpenUSD -- \
   openusdconnect-server --base scene.usda
 ```
 
-Use repeatable `--plugin-path` and `--dll-dir` options for project additions, or
-`--renderman-root /path/to/RenderManProServer` to configure hdPrman.
+Use `--python-path /external/site-packages` for Python bindings outside the
+prefix and `--python-executable` to select the matching interpreter. Use
+repeatable `--plugin-path` and `--dll-dir` options for project additions, or
+`--renderman-root /path/to/RenderManProServer` to configure or override
+hdPrman. An inherited valid `RMANTREE` is also configured.
 
-The environment must expose the intended `pxr` bindings. For custom plugins,
-configure:
+The launchers validate the selected `pxr` package before changing the runtime
+environment. They deliberately do not recursively search unrelated virtual
+environments: an absolute CMake Python install directory has no discoverable
+relationship to the OpenUSD prefix. For custom plugins, configure:
 
 - plugin discovery through `PXR_PLUGINPATH_NAME`
 - native dependencies through `PATH` on Windows, `LD_LIBRARY_PATH` on Linux,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -117,19 +117,33 @@ checks `Lib/site-packages` on Windows, `lib/pythonX.Y/site-packages` and
 `dist-packages` on Unix, the legacy `lib/python` layout, and the active venv's
 site-packages. Install-prefix locations take precedence over the active venv.
 
-If OpenUSD's bindings were installed into a venv, activate it before running
-the launcher. This works whether the venv itself is the native install prefix
-or `PXR_PYTHON_INSTALL_DIR` points into a venv outside the native prefix:
+The active interpreter must match the Python version against which OpenUSD was
+built; a mismatched interpreter cannot load the native `pxr` extension modules.
+When the bindings, their dependencies (such as PySide6), or the matching
+interpreter live in a separate virtual environment (including the common layout
+where the OpenUSD install prefix and the venv are different directories),
+activate that venv before configuring the runtime:
+
+- **uv-managed venv:** create it with `uv venv` and run the activation command it
+  prints, or use `uv run` so the project venv is selected automatically.
+- **pip/`python -m venv` venv:** activate with `.venv\Scripts\Activate.ps1` in
+  PowerShell, or `source .venv/bin/activate` in Bash/Zsh.
 
 ```powershell
-& "D:\OpenUSD\.venv\Scripts\Activate.ps1"
-. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall"
+& "E:\OpenUSD_venv\Scripts\Activate.ps1"
+. .\scripts\openusd_env.ps1 "E:\OpenUSD_install"
 ```
 
-The active interpreter must match the Python version against which OpenUSD was
-built. Activating the venv also ensures generated commands such as
-`usdview.cmd` resolve that interpreter from `PATH`. Pass `-PythonPath` only if
-the bindings are neither under the install prefix nor in the active venv.
+Activating the venv puts the matching interpreter first on `PATH`, so both the
+runtime configuration and generated commands such as `usdview.cmd` resolve it.
+Pass `-PythonExecutable` (or `--python-executable` for the wrapper) to select
+that interpreter without activating, and `-PythonPath` only if the bindings are
+neither under the install prefix nor in the active venv.
+
+`uv run` always uses the project `.venv`, so with another venv active it may
+print a `VIRTUAL_ENV does not match` warning. That warning is harmless: the
+child process inherits the sourced OpenUSD environment for `pxr` and the
+viewers, while `openusdconnect` and its dependencies resolve from `.venv`.
 
 A valid `RMANTREE` already present in the process is configured automatically.
 Use `-RenderManRoot` to select or override it, and pass arrays to `-PluginPath`
@@ -171,10 +185,12 @@ repeatable `--plugin-path` and `--dll-dir` options for project additions, or
 `--renderman-root /path/to/RenderManProServer` to configure or override
 hdPrman. An inherited valid `RMANTREE` is also configured.
 
-The launchers validate the selected `pxr` package before changing the runtime
-environment. They deliberately do not recursively search unrelated virtual
-environments: an absolute CMake Python install directory has no discoverable
-relationship to the OpenUSD prefix. For custom plugins, configure:
+The launchers import the selected `pxr` package with the resolved interpreter
+before changing the runtime environment, so an interpreter whose Python version
+cannot load the native modules fails immediately rather than at first use. They
+deliberately do not recursively search unrelated virtual environments: an
+absolute CMake Python install directory has no discoverable relationship to the
+OpenUSD prefix. For custom plugins, configure:
 
 - plugin discovery through `PXR_PLUGINPATH_NAME`
 - native dependencies through `PATH` on Windows, `LD_LIBRARY_PATH` on Linux,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ Configure the same compatible OpenUSD build and plugin environment used by the
 project. For example, in PowerShell:
 
 ```powershell
-.\scripts\openusd_env.ps1 "C:\path\to\OpenUSDInstall"
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall"
 ```
 
 The [runtime guide](cli-reference.md#openusd-runtime-and-custom-plugins) covers

--- a/docs/testing-setup.md
+++ b/docs/testing-setup.md
@@ -22,8 +22,8 @@ Configure the project OpenUSD runtime first. On PowerShell:
 
 Current Windows and Unix OpenUSD Python layouts and the legacy `lib/python`
 layout are detected automatically. If the bindings were installed into a
-separate virtual environment, add
-`-PythonPath "D:\OpenUSD\.venv\Lib\site-packages"`. An existing valid
+virtual environment, activate it first; its site-packages is also searched.
+Use `-PythonPath` only for bindings outside both locations. An existing valid
 `RMANTREE` is also configured automatically.
 
 Then install the normal development environment without the bundled runtime:

--- a/docs/testing-setup.md
+++ b/docs/testing-setup.md
@@ -17,8 +17,14 @@ Unreal Engine, RenderMan, operating-system mounts, or large external assets.
 Configure the project OpenUSD runtime first. On PowerShell:
 
 ```powershell
-.\scripts\openusd_env.ps1 "C:\path\to\OpenUSDInstall"
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall"
 ```
+
+Current Windows and Unix OpenUSD Python layouts and the legacy `lib/python`
+layout are detected automatically. If the bindings were installed into a
+separate virtual environment, add
+`-PythonPath "D:\OpenUSD\.venv\Lib\site-packages"`. An existing valid
+`RMANTREE` is also configured automatically.
 
 Then install the normal development environment without the bundled runtime:
 
@@ -44,6 +50,8 @@ For automation or other shells, configure the test command through the wrapper:
 uv run python scripts/run_with_openusd.py --usd-root /path/to/OpenUSD -- \
   pytest tests/ -v
 ```
+
+The wrapper accepts the equivalent `--python-path` option.
 
 Add `--renderman-root /path/to/RenderManProServer` when running the visual tier.
 

--- a/scripts/openusd_env.ps1
+++ b/scripts/openusd_env.ps1
@@ -1,17 +1,32 @@
 <#
 .SYNOPSIS
-Activates a project OpenUSD installation in the current PowerShell terminal.
+Activates an OpenUSD runtime in the current PowerShell process.
 
 .PARAMETER UsdRoot
-OpenUSD install directory containing bin and lib.
+OpenUSD install prefix.
+
+.PARAMETER PythonPath
+Directory containing pxr when the bindings are outside UsdRoot.
+
+.PARAMETER PythonExecutable
+Matching Python executable to place first on PATH. The active Python is used by default.
 
 .EXAMPLE
-.\scripts\openusd_env.ps1 "C:\path\to\OpenUSDInstall"
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall"
+
+.EXAMPLE
+. .\scripts\openusd_env.ps1 "D:\OpenUSDInstall" `
+    -PythonPath "D:\OpenUSD\.venv\Lib\site-packages" `
+    -PythonExecutable "D:\OpenUSD\.venv\Scripts\python.exe"
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory, Position = 0)]
     [string] $UsdRoot,
+
+    [string] $PythonPath,
+
+    [string] $PythonExecutable,
 
     [string] $RenderManRoot,
 
@@ -22,90 +37,63 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-function Resolve-RequiredDirectory {
-    param(
-        [string] $Path,
-        [string] $Label
-    )
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
-        throw "$Label does not exist: $Path"
+if ($PythonExecutable) {
+    if (-not (Test-Path -LiteralPath $PythonExecutable -PathType Leaf)) {
+        throw "Python executable does not exist: $PythonExecutable"
     }
-    return (Resolve-Path -LiteralPath $Path).Path.TrimEnd('\', '/')
-}
-
-function Add-EnvironmentPath {
-    param(
-        [string] $Name,
-        [string[]] $Path
-    )
-
-    $values = @($Path | Where-Object { $_ -and (Test-Path -LiteralPath $_ -PathType Container) })
-    $current = [Environment]::GetEnvironmentVariable($Name, "Process")
-    if ($current) {
-        $values += $current -split [IO.Path]::PathSeparator
+    $python = (Resolve-Path -LiteralPath $PythonExecutable).Path
+} else {
+    $pythonCommand = Get-Command python -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $pythonCommand) {
+        $pythonCommand = Get-Command python3 -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
     }
-
-    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
-    $unique = foreach ($value in $values) {
-        $resolved = if (Test-Path -LiteralPath $value -PathType Container) {
-            (Resolve-Path -LiteralPath $value).Path.TrimEnd('\', '/')
-        } else {
-            $value
-        }
-        if ($seen.Add($resolved)) { $resolved }
+    if (-not $pythonCommand) {
+        throw "Python was not found. Activate the matching venv or pass -PythonExecutable."
     }
-    if ($unique) {
-        [Environment]::SetEnvironmentVariable(
-            $Name,
-            ($unique -join [IO.Path]::PathSeparator),
-            "Process"
-        )
-    }
+    $python = $pythonCommand.Source
 }
 
-$usd = Resolve-RequiredDirectory $UsdRoot "OpenUSD root"
-$usdPython = Join-Path $usd "lib\python"
-if (-not (Test-Path -LiteralPath (Join-Path $usdPython "pxr\__init__.py") -PathType Leaf)) {
-    throw "No pxr Python package found under OpenUSD install: $usd"
+$resolver = Join-Path $PSScriptRoot "openusd_runtime.py"
+$arguments = @(
+    $resolver
+    "--usd-root"
+    $UsdRoot
+    "--python-executable"
+    $python
+    "--format"
+    "json"
+)
+if ($PythonPath) {
+    $arguments += @("--python-path", $PythonPath)
 }
-
-$plugins = foreach ($path in $PluginPath) {
-    Resolve-RequiredDirectory $path "Plugin path"
-}
-$nativeDirs = foreach ($path in $DllDir) {
-    Resolve-RequiredDirectory $path "Native-library directory"
-}
-
-$env:OPENUSDCONNECT_USD_ROOT = $usd
-Add-EnvironmentPath "PYTHONPATH" @($usdPython)
-Add-EnvironmentPath "PATH" @((Join-Path $usd "bin"), (Join-Path $usd "lib"))
-Add-EnvironmentPath "PATH" @($nativeDirs)
-Add-EnvironmentPath "PXR_PLUGINPATH_NAME" @($plugins)
-
 if ($RenderManRoot) {
-    $rman = Resolve-RequiredDirectory $RenderManRoot "RenderMan root"
-    $env:RMANTREE = $rman
-    Add-EnvironmentPath "PATH" @((Join-Path $rman "bin"), (Join-Path $rman "lib"))
-
-    $rmanPlugins = Join-Path $rman "lib\plugins"
-    $usdPlugin = Join-Path $usd "plugin\usd"
-    $env:RMAN_SHADERPATH = @(
-        (Join-Path $rman "lib\shaders")
-        (Join-Path $usdPlugin "resources\shaders")
-    ) -join [IO.Path]::PathSeparator
-    $env:RMAN_RIXPLUGINPATH = $rmanPlugins
-    $env:RMAN_TEXTUREPATH = @(
-        (Join-Path $rman "lib\textures")
-        $rmanPlugins
-        $usdPlugin
-    ) -join [IO.Path]::PathSeparator
-    $env:RMAN_DISPLAYPATH = $rmanPlugins
-    $env:RMAN_PROCEDURALPATH = $rmanPlugins
+    $arguments += @("--renderman-root", $RenderManRoot)
+}
+foreach ($path in $PluginPath) {
+    $arguments += @("--plugin-path", $path)
+}
+foreach ($path in $DllDir) {
+    $arguments += @("--dll-dir", $path)
 }
 
-Write-Host "OpenUSD environment ready: $usd"
-Write-Host "Python bindings: $usdPython"
-if ($RenderManRoot) {
-    Write-Host "RenderMan: $env:RMANTREE"
+$json = & $python @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "OpenUSD environment resolution failed with exit code $LASTEXITCODE."
+}
+$configuration = $json | ConvertFrom-Json
+foreach ($property in $configuration.environment.PSObject.Properties) {
+    [Environment]::SetEnvironmentVariable(
+        $property.Name,
+        [string] $property.Value,
+        "Process"
+    )
+}
+
+Write-Host "OpenUSD environment ready: $($configuration.usd_root)"
+Write-Host "Python bindings: $($configuration.python_path)"
+Write-Host "Python executable: $python"
+if ($configuration.renderman_root) {
+    Write-Host "RenderMan: $($configuration.renderman_root)"
 }

--- a/scripts/openusd_env.ps1
+++ b/scripts/openusd_env.ps1
@@ -16,7 +16,6 @@ Matching Python executable to place first on PATH. The active Python is used by 
 
 .EXAMPLE
 . .\scripts\openusd_env.ps1 "D:\OpenUSDInstall" `
-    -PythonPath "D:\OpenUSD\.venv\Lib\site-packages" `
     -PythonExecutable "D:\OpenUSD\.venv\Scripts\python.exe"
 #>
 [CmdletBinding()]

--- a/scripts/openusd_env.ps1
+++ b/scripts/openusd_env.ps1
@@ -77,9 +77,15 @@ foreach ($path in $DllDir) {
     $arguments += @("--dll-dir", $path)
 }
 
+# Relax the Stop preference so the resolver's own stderr prints as written,
+# instead of being wrapped in a NativeCommandError with a PowerShell stack trace.
+$previousErrorAction = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
 $json = & $python @arguments
-if ($LASTEXITCODE -ne 0) {
-    throw "OpenUSD environment resolution failed with exit code $LASTEXITCODE."
+$resolverExitCode = $LASTEXITCODE
+$ErrorActionPreference = $previousErrorAction
+if ($resolverExitCode -ne 0) {
+    return
 }
 $configuration = $json | ConvertFrom-Json
 foreach ($property in $configuration.environment.PSObject.Properties) {

--- a/scripts/openusd_env.sh
+++ b/scripts/openusd_env.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env sh
+# Source this file to activate an OpenUSD runtime in Bash or Zsh.
+
+if [ -n "${BASH_VERSION:-}" ] && [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    echo "openusd_env.sh must be sourced: source scripts/openusd_env.sh <OpenUSD-prefix>" >&2
+    exit 2
+fi
+if [ -n "${ZSH_VERSION:-}" ]; then
+    case ${ZSH_EVAL_CONTEXT:-} in
+        *:file) ;;
+        *)
+            echo "openusd_env.sh must be sourced: source scripts/openusd_env.sh <OpenUSD-prefix>" >&2
+            exit 2
+            ;;
+    esac
+fi
+
+_openusd_activate() {
+    if [ "$#" -lt 1 ]; then
+        echo "usage: source scripts/openusd_env.sh <OpenUSD-prefix> [options]" >&2
+        return 2
+    fi
+
+    _openusd_root=$1
+    shift
+    if [ -n "${OPENUSDCONNECT_ENV_PYTHON:-}" ]; then
+        _openusd_python=$OPENUSDCONNECT_ENV_PYTHON
+    elif command -v python3 >/dev/null 2>&1; then
+        _openusd_python=$(command -v python3)
+    elif command -v python >/dev/null 2>&1; then
+        _openusd_python=$(command -v python)
+    else
+        echo "Python was not found. Activate the matching venv or set OPENUSDCONNECT_ENV_PYTHON." >&2
+        return 2
+    fi
+
+    if [ -n "${BASH_VERSION:-}" ]; then
+        _openusd_script=${BASH_SOURCE[0]}
+    else
+        _openusd_script=$0
+    fi
+    _openusd_script_dir=$(CDPATH= cd -- "$(dirname -- "$_openusd_script")" && pwd)
+    _openusd_output=$(
+        "$_openusd_python" "$_openusd_script_dir/openusd_runtime.py" \
+            --usd-root "$_openusd_root" \
+            --python-executable "$_openusd_python" \
+            --format posix \
+            "$@"
+    ) || return $?
+    eval "$_openusd_output"
+}
+
+_openusd_activate "$@"
+_openusd_status=$?
+_openusd_finish() {
+    unset _openusd_output _openusd_python _openusd_root _openusd_script _openusd_script_dir
+    unset _openusd_status
+    unset -f _openusd_activate _openusd_finish 2>/dev/null || \
+        unfunction _openusd_activate _openusd_finish 2>/dev/null
+    return "$1"
+}
+_openusd_finish "$_openusd_status"
+return $? 2>/dev/null || exit $?

--- a/scripts/openusd_runtime.py
+++ b/scripts/openusd_runtime.py
@@ -7,10 +7,18 @@ import json
 import os
 import shlex
 import sys
+import sysconfig
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 USD_ROOT_ENV = "OPENUSDCONNECT_USD_ROOT"
+
+
+def _active_venv_python_paths() -> list[Path]:
+    if sys.prefix == sys.base_prefix:
+        return []
+    paths = sysconfig.get_paths()
+    return [Path(paths[name]).resolve() for name in ("purelib", "platlib")]
 
 
 def _prepend(env: dict[str, str], key: str, paths: Sequence[Path]) -> None:
@@ -36,14 +44,15 @@ def _python_path(usd_root: Path, python_path: str | os.PathLike | None = None) -
             candidates.extend(sorted(lib.glob("python*/site-packages")))
             candidates.extend(sorted(lib.glob("python*/dist-packages")))
         candidates.append(usd_root / "lib" / "python")
+        candidates.extend(_active_venv_python_paths())
     for candidate in candidates:
         if (candidate / "pxr" / "__init__.py").is_file():
             return candidate
     if python_path is not None:
         raise RuntimeError(f"no pxr Python package found in Python path: {candidates[0]}")
     raise RuntimeError(
-        f"no pxr Python package found under OpenUSD install: {usd_root}; "
-        "pass --python-path when the bindings were installed outside the prefix"
+        f"no pxr Python package found under OpenUSD install or active venv: {usd_root}; "
+        "pass --python-path when the bindings are in another location"
     )
 
 

--- a/scripts/openusd_runtime.py
+++ b/scripts/openusd_runtime.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import shlex
+import subprocess
 import sys
 import sysconfig
 from collections.abc import Mapping, Sequence
@@ -147,6 +148,50 @@ def environment_delta(base: Mapping[str, str], configured: Mapping[str, str]) ->
     return {key: value for key, value in configured.items() if base.get(key) != value}
 
 
+def verify_bindings(
+    env: Mapping[str, str],
+    python_path: str | os.PathLike,
+    python_executable: str | os.PathLike | None = None,
+) -> str:
+    """Import pxr with the resolved interpreter to confirm the bindings load.
+
+    Finding the ``pxr`` package on disk is not enough: its native modules are
+    compiled against one specific Python version, so an interpreter that differs
+    from the one OpenUSD was built against fails at import time. Run that import
+    in a subprocess under the configured environment and raise a clear error
+    when it fails instead of leaving a cryptic DLL/so failure for a later launch.
+    """
+    interpreter = (
+        Path(python_executable).expanduser().resolve()
+        if python_executable is not None
+        else Path(sys.executable)
+    )
+    probe = "from pxr import Tf, Usd; print(Usd.GetVersion())"
+    result = subprocess.run(
+        [str(interpreter), "-c", probe],
+        env=dict(env),
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        tail = detail[-1] if detail else "unknown import error"
+        raise RuntimeError(
+            "could not import OpenUSD (pxr) with the selected interpreter.\n"
+            f"  interpreter:  {interpreter}\n"
+            f"  bindings:     {python_path}\n"
+            f"  import error: {tail}\n"
+            "\n"
+            "The interpreter's Python version likely differs from the one OpenUSD "
+            "was built against.\n"
+            "Fix it by activating the matching virtual environment, or by selecting "
+            "its interpreter\n"
+            "with -PythonExecutable (openusd_env.ps1) or --python-executable "
+            "(run_with_openusd.py)."
+        )
+    return result.stdout.strip()
+
+
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Resolve an OpenUSD runtime environment.")
     parser.add_argument(
@@ -179,6 +224,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             python_executable=args.python_executable,
             renderman_root=args.renderman_root,
         )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    try:
+        verify_bindings(env, python_path, args.python_executable)
     except RuntimeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/scripts/openusd_runtime.py
+++ b/scripts/openusd_runtime.py
@@ -1,0 +1,196 @@
+"""Resolve an OpenUSD runtime environment for launchers and shell adapters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+USD_ROOT_ENV = "OPENUSDCONNECT_USD_ROOT"
+
+
+def _prepend(env: dict[str, str], key: str, paths: Sequence[Path]) -> None:
+    values = [str(path.resolve()) for path in paths if path.is_dir()]
+    values.extend(filter(None, env.get(key, "").split(os.pathsep)))
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = os.path.normcase(os.path.abspath(value))
+        if normalized not in seen:
+            seen.add(normalized)
+            unique.append(value)
+    if unique:
+        env[key] = os.pathsep.join(unique)
+
+
+def _python_path(usd_root: Path, python_path: str | os.PathLike | None = None) -> Path:
+    if python_path is not None:
+        candidates = [Path(python_path).expanduser().resolve()]
+    else:
+        candidates = [usd_root / "Lib" / "site-packages"]
+        for lib in (usd_root / "lib", usd_root / "lib64"):
+            candidates.extend(sorted(lib.glob("python*/site-packages")))
+            candidates.extend(sorted(lib.glob("python*/dist-packages")))
+        candidates.append(usd_root / "lib" / "python")
+    for candidate in candidates:
+        if (candidate / "pxr" / "__init__.py").is_file():
+            return candidate
+    if python_path is not None:
+        raise RuntimeError(f"no pxr Python package found in Python path: {candidates[0]}")
+    raise RuntimeError(
+        f"no pxr Python package found under OpenUSD install: {usd_root}; "
+        "pass --python-path when the bindings were installed outside the prefix"
+    )
+
+
+def _loader_path_key() -> str:
+    if os.name == "nt":
+        return "PATH"
+    if sys.platform == "darwin":
+        return "DYLD_LIBRARY_PATH"
+    return "LD_LIBRARY_PATH"
+
+
+def _required_dirs(values: Sequence[str | os.PathLike], label: str) -> list[Path]:
+    paths = [Path(value).expanduser().resolve() for value in values]
+    missing = [str(path) for path in paths if not path.is_dir()]
+    if missing:
+        raise RuntimeError(f"{label} does not exist: {', '.join(missing)}")
+    return paths
+
+
+def _required_file(value: str | os.PathLike, label: str) -> Path:
+    path = Path(value).expanduser().resolve()
+    if not path.is_file():
+        raise RuntimeError(f"{label} does not exist: {path}")
+    return path
+
+
+def build_environment(
+    usd_root: str | os.PathLike,
+    *,
+    base: Mapping[str, str] | None = None,
+    plugin_paths: Sequence[str | os.PathLike] = (),
+    dll_dirs: Sequence[str | os.PathLike] = (),
+    python_path: str | os.PathLike | None = None,
+    python_executable: str | os.PathLike | None = None,
+    renderman_root: str | os.PathLike | None = None,
+) -> tuple[dict[str, str], Path]:
+    """Build an environment for an OpenUSD install prefix."""
+    root = Path(usd_root).expanduser().resolve()
+    if not root.is_dir():
+        raise RuntimeError(f"OpenUSD root does not exist: {root}")
+    env = dict(os.environ if base is None else base)
+    selected_python_path = _python_path(root, python_path)
+    env[USD_ROOT_ENV] = str(root)
+
+    _prepend(env, "PYTHONPATH", [selected_python_path])
+    _prepend(env, "PATH", [root / "bin"])
+    native_dirs = [
+        root / "lib",
+        root / "lib64",
+        *_required_dirs(dll_dirs, "native-library directory"),
+    ]
+    loader_key = _loader_path_key()
+    _prepend(env, loader_key, native_dirs)
+    if os.name == "nt":
+        _prepend(env, "PATH", native_dirs)
+    if python_executable is not None:
+        executable = _required_file(python_executable, "Python executable")
+        _prepend(env, "PATH", [executable.parent])
+        env["OPENUSDCONNECT_PYTHON_EXECUTABLE"] = str(executable)
+    _prepend(env, "PXR_PLUGINPATH_NAME", _required_dirs(plugin_paths, "plugin path"))
+
+    selected_renderman_root = renderman_root or env.get("RMANTREE")
+    if selected_renderman_root:
+        rman = Path(selected_renderman_root).expanduser().resolve()
+        if not rman.is_dir():
+            raise RuntimeError(f"RenderMan root does not exist: {rman}")
+        env["RMANTREE"] = str(rman)
+        _prepend(env, "PATH", [rman / "bin"])
+        _prepend(env, loader_key, [rman / "bin", rman / "lib"])
+        if os.name == "nt":
+            _prepend(env, "PATH", [rman / "lib"])
+        plugins = rman / "lib" / "plugins"
+        plugin_usd = root / "plugin" / "usd"
+        env.update(
+            {
+                "RMAN_SHADERPATH": os.pathsep.join(
+                    [str(rman / "lib" / "shaders"), str(plugin_usd / "resources" / "shaders")]
+                ),
+                "RMAN_RIXPLUGINPATH": str(plugins),
+                "RMAN_TEXTUREPATH": os.pathsep.join(
+                    [str(rman / "lib" / "textures"), str(plugins), str(plugin_usd)]
+                ),
+                "RMAN_DISPLAYPATH": str(plugins),
+                "RMAN_PROCEDURALPATH": str(plugins),
+            }
+        )
+    return env, selected_python_path
+
+
+def environment_delta(base: Mapping[str, str], configured: Mapping[str, str]) -> dict[str, str]:
+    """Return only variables changed by runtime configuration."""
+    return {key: value for key, value in configured.items() if base.get(key) != value}
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Resolve an OpenUSD runtime environment.")
+    parser.add_argument(
+        "--usd-root",
+        default=os.environ.get(USD_ROOT_ENV),
+        help=f"OpenUSD install prefix (or set {USD_ROOT_ENV}).",
+    )
+    parser.add_argument("--python-path", help="Directory containing the pxr package.")
+    parser.add_argument("--python-executable", help="Python executable to place first on PATH.")
+    parser.add_argument("--plugin-path", action="append", default=[])
+    parser.add_argument("--dll-dir", action="append", default=[])
+    parser.add_argument("--renderman-root")
+    parser.add_argument("--format", choices=("json", "posix"), default="json")
+    args = parser.parse_args(argv)
+    if not args.usd_root:
+        parser.error(f"--usd-root is required unless {USD_ROOT_ENV} is set")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    base = dict(os.environ)
+    try:
+        env, python_path = build_environment(
+            args.usd_root,
+            base=base,
+            plugin_paths=args.plugin_path,
+            dll_dirs=args.dll_dir,
+            python_path=args.python_path,
+            python_executable=args.python_executable,
+            renderman_root=args.renderman_root,
+        )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    delta = environment_delta(base, env)
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "environment": delta,
+                    "python_path": str(python_path),
+                    "renderman_root": env.get("RMANTREE"),
+                    "usd_root": env[USD_ROOT_ENV],
+                },
+                separators=(",", ":"),
+            )
+        )
+    else:
+        for key, value in sorted(delta.items()):
+            print(f"export {key}={shlex.quote(value)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_with_openusd.py
+++ b/scripts/run_with_openusd.py
@@ -10,11 +10,11 @@ from collections.abc import Sequence
 from pathlib import Path
 
 if __package__:
-    from .openusd_runtime import USD_ROOT_ENV, build_environment
+    from .openusd_runtime import USD_ROOT_ENV, build_environment, verify_bindings
 else:
-    from openusd_runtime import USD_ROOT_ENV, build_environment
+    from openusd_runtime import USD_ROOT_ENV, build_environment, verify_bindings
 
-__all__ = ["USD_ROOT_ENV", "build_environment"]
+__all__ = ["USD_ROOT_ENV", "build_environment", "verify_bindings"]
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -85,6 +85,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             python_executable=args.python_executable,
             renderman_root=args.renderman_root,
         )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    try:
+        verify_bindings(env, python_path, args.python_executable)
     except RuntimeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/scripts/run_with_openusd.py
+++ b/scripts/run_with_openusd.py
@@ -6,107 +6,15 @@ import argparse
 import os
 import subprocess
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 
-USD_ROOT_ENV = "OPENUSDCONNECT_USD_ROOT"
+if __package__:
+    from .openusd_runtime import USD_ROOT_ENV, build_environment
+else:
+    from openusd_runtime import USD_ROOT_ENV, build_environment
 
-
-def _prepend(env: dict[str, str], key: str, paths: Sequence[Path]) -> None:
-    values = [str(path.resolve()) for path in paths if path.is_dir()]
-    values.extend(filter(None, env.get(key, "").split(os.pathsep)))
-    unique: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        normalized = os.path.normcase(os.path.abspath(value))
-        if normalized not in seen:
-            seen.add(normalized)
-            unique.append(value)
-    if unique:
-        env[key] = os.pathsep.join(unique)
-
-
-def _python_path(usd_root: Path) -> Path:
-    candidates = [usd_root / "lib" / "python"]
-    for lib in (usd_root / "lib", usd_root / "lib64"):
-        candidates.extend(sorted(lib.glob("python*/site-packages")))
-        candidates.extend(sorted(lib.glob("python*/dist-packages")))
-    for candidate in candidates:
-        if (candidate / "pxr" / "__init__.py").is_file():
-            return candidate
-    raise RuntimeError(f"no pxr Python package found under OpenUSD install: {usd_root}")
-
-
-def _loader_path_key() -> str | None:
-    if os.name == "nt":
-        return "PATH"
-    if sys.platform == "darwin":
-        return "DYLD_LIBRARY_PATH"
-    return "LD_LIBRARY_PATH"
-
-
-def _required_dirs(values: Sequence[str | os.PathLike], label: str) -> list[Path]:
-    paths = [Path(value).expanduser().resolve() for value in values]
-    missing = [str(path) for path in paths if not path.is_dir()]
-    if missing:
-        raise RuntimeError(f"{label} does not exist: {', '.join(missing)}")
-    return paths
-
-
-def build_environment(
-    usd_root: str | os.PathLike,
-    *,
-    base: Mapping[str, str] | None = None,
-    plugin_paths: Sequence[str | os.PathLike] = (),
-    dll_dirs: Sequence[str | os.PathLike] = (),
-    renderman_root: str | os.PathLike | None = None,
-) -> tuple[dict[str, str], Path]:
-    """Build a child environment for the selected OpenUSD installation."""
-    root = Path(usd_root).expanduser().resolve()
-    python_path = _python_path(root)
-    env = dict(os.environ if base is None else base)
-    env[USD_ROOT_ENV] = str(root)
-
-    _prepend(env, "PYTHONPATH", [python_path])
-    _prepend(env, "PATH", [root / "bin"])
-    native_dirs = [root / "lib", *_required_dirs(dll_dirs, "native-library directory")]
-    loader_key = _loader_path_key()
-    if loader_key:
-        _prepend(env, loader_key, native_dirs)
-    if os.name == "nt":
-        _prepend(env, "PATH", native_dirs)
-    _prepend(
-        env,
-        "PXR_PLUGINPATH_NAME",
-        _required_dirs(plugin_paths, "plugin path"),
-    )
-
-    if renderman_root:
-        rman = Path(renderman_root).expanduser().resolve()
-        if not rman.is_dir():
-            raise RuntimeError(f"RenderMan root does not exist: {rman}")
-        env["RMANTREE"] = str(rman)
-        _prepend(env, "PATH", [rman / "bin"])
-        if loader_key:
-            _prepend(env, loader_key, [rman / "bin", rman / "lib"])
-        if os.name == "nt":
-            _prepend(env, "PATH", [rman / "lib"])
-        plugins = rman / "lib" / "plugins"
-        plugin_usd = root / "plugin" / "usd"
-        env.update(
-            {
-                "RMAN_SHADERPATH": os.pathsep.join(
-                    [str(rman / "lib" / "shaders"), str(plugin_usd / "resources" / "shaders")]
-                ),
-                "RMAN_RIXPLUGINPATH": str(plugins),
-                "RMAN_TEXTUREPATH": os.pathsep.join(
-                    [str(rman / "lib" / "textures"), str(plugins), str(plugin_usd)]
-                ),
-                "RMAN_DISPLAYPATH": str(plugins),
-                "RMAN_PROCEDURALPATH": str(plugins),
-            }
-        )
-    return env, python_path
+__all__ = ["USD_ROOT_ENV", "build_environment"]
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -117,6 +25,16 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--usd-root",
         default=os.environ.get(USD_ROOT_ENV),
         help=f"OpenUSD install prefix (or set {USD_ROOT_ENV}).",
+    )
+    parser.add_argument(
+        "--python-path",
+        default=None,
+        help="Directory containing pxr when bindings are installed outside --usd-root.",
+    )
+    parser.add_argument(
+        "--python-executable",
+        default=None,
+        help="Python executable used for a command beginning with 'python'.",
     )
     parser.add_argument(
         "--plugin-path",
@@ -146,13 +64,13 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return args
 
 
-def _resolve_command(command: Sequence[str]) -> list[str]:
+def _resolve_command(command: Sequence[str], python_executable: str | None = None) -> list[str]:
     resolved = list(command)
     executable = resolved[0].lower()
     if executable in {"python", "python.exe", "python3", "python3.exe"} or executable.startswith(
         "python3."
     ):
-        resolved[0] = sys.executable
+        resolved[0] = str(Path(python_executable).resolve()) if python_executable else sys.executable
     return resolved
 
 
@@ -163,13 +81,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.usd_root,
             plugin_paths=args.plugin_path,
             dll_dirs=args.dll_dir,
+            python_path=args.python_path,
+            python_executable=args.python_executable,
             renderman_root=args.renderman_root,
         )
     except RuntimeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(f"OpenUSD runtime: {Path(args.usd_root).resolve()} (Python: {python_path})", flush=True)
-    command = _resolve_command(args.command)
+    command = _resolve_command(args.command, args.python_executable)
     try:
         return subprocess.run(command, env=env, check=False).returncode
     except FileNotFoundError:

--- a/tests/unit/test_bundled_usd_runtime.py
+++ b/tests/unit/test_bundled_usd_runtime.py
@@ -4,7 +4,21 @@ import os
 import tomllib
 from pathlib import Path
 
+import pytest
+
 import openusdconnect._runtime as runtime
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime_env(monkeypatch):
+    """Isolate runtime selection from a shell that already configured OpenUSD.
+
+    The documented setup sources ``openusd_env`` and sets these variables, which
+    would otherwise short-circuit ``select_runtime`` and mask the behavior under
+    test. Individual tests still set them explicitly when that is the case.
+    """
+    monkeypatch.delenv(runtime.USD_ROOT_ENV, raising=False)
+    monkeypatch.delenv(runtime.BUNDLED_USD_ENV, raising=False)
 
 
 def test_bundled_runtime_ignores_only_conflicting_pxr(monkeypatch, tmp_path):

--- a/tests/unit/test_openusd_env_powershell.py
+++ b/tests/unit/test_openusd_env_powershell.py
@@ -16,8 +16,13 @@ SCRIPT = Path(__file__).parents[2] / "scripts" / "openusd_env.ps1"
 
 
 def _pxr_package(path: Path) -> Path:
-    (path / "pxr").mkdir(parents=True)
-    (path / "pxr" / "__init__.py").touch()
+    pkg = path / "pxr"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+    (pkg / "Tf").mkdir()
+    (pkg / "Tf" / "__init__.py").touch()
+    (pkg / "Usd").mkdir()
+    (pkg / "Usd" / "__init__.py").write_text("def GetVersion():\n    return (0, 0, 0)\n")
     return path
 
 

--- a/tests/unit/test_openusd_env_powershell.py
+++ b/tests/unit/test_openusd_env_powershell.py
@@ -1,0 +1,85 @@
+"""Tests for the PowerShell OpenUSD environment activator."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+POWERSHELL = shutil.which("pwsh") or shutil.which("powershell")
+SCRIPT = Path(__file__).parents[2] / "scripts" / "openusd_env.ps1"
+
+
+def _pxr_package(path: Path) -> Path:
+    (path / "pxr").mkdir(parents=True)
+    (path / "pxr" / "__init__.py").touch()
+    return path
+
+
+def _run_script(root: Path, *, python_path: Path | None = None, rman: Path | None = None):
+    if POWERSHELL is None:
+        pytest.skip("PowerShell is unavailable")
+
+    env = dict(os.environ)
+    env.update(TEST_SCRIPT=str(SCRIPT), TEST_USD_ROOT=str(root))
+    env["RMANTREE"] = "" if rman is None else str(rman)
+    arguments = ""
+    if python_path is not None:
+        env["TEST_PYTHON_PATH"] = str(python_path)
+        arguments = " -PythonPath $env:TEST_PYTHON_PATH"
+    command = (
+        f". $env:TEST_SCRIPT $env:TEST_USD_ROOT{arguments}; "
+        "[PSCustomObject]@{PythonPath=$env:PYTHONPATH; Path=$env:PATH; "
+        "RenderMan=$env:RMANTREE; LoaderPython=$env:OPENUSDCONNECT_PYTHON_EXECUTABLE} "
+        "| ConvertTo-Json -Compress"
+    )
+    result = subprocess.run(
+        [POWERSHELL, "-NoProfile", "-Command", command],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout.splitlines()[-1])
+
+
+def test_discovers_current_windows_python_layout(tmp_path):
+    root = tmp_path / "OpenUSD"
+    root.mkdir()
+    python_path = _pxr_package(root / "Lib" / "site-packages")
+
+    result = _run_script(root)
+
+    assert result["PythonPath"].split(os.pathsep)[0] == str(python_path)
+    assert Path(result["LoaderPython"]).resolve() == Path(sys.executable).resolve()
+
+
+def test_accepts_python_bindings_outside_prefix(tmp_path):
+    root = tmp_path / "OpenUSD"
+    root.mkdir()
+    python_path = _pxr_package(tmp_path / "venv" / "Lib" / "site-packages")
+
+    result = _run_script(root, python_path=python_path)
+
+    assert result["PythonPath"].split(os.pathsep)[0] == str(python_path)
+
+
+def test_configures_inherited_rmantree(tmp_path):
+    root = tmp_path / "OpenUSD"
+    root.mkdir()
+    _pxr_package(root / "Lib" / "site-packages")
+    rman = tmp_path / "RenderMan"
+    (rman / "bin").mkdir(parents=True)
+    (rman / "lib").mkdir()
+
+    result = _run_script(root, rman=rman)
+
+    path = result["Path"].split(os.pathsep)
+    assert result["RenderMan"] == str(rman)
+    assert str(rman / "bin") in path
+    assert str(rman / "lib") in path

--- a/tests/unit/test_openusd_env_powershell.py
+++ b/tests/unit/test_openusd_env_powershell.py
@@ -35,6 +35,7 @@ def _run_script(root: Path, *, python_path: Path | None = None, rman: Path | Non
     command = (
         f". $env:TEST_SCRIPT $env:TEST_USD_ROOT{arguments}; "
         "[PSCustomObject]@{PythonPath=$env:PYTHONPATH; Path=$env:PATH; "
+        "LdLibraryPath=$env:LD_LIBRARY_PATH; DyldLibraryPath=$env:DYLD_LIBRARY_PATH; "
         "RenderMan=$env:RMANTREE; LoaderPython=$env:OPENUSDCONNECT_PYTHON_EXECUTABLE} "
         "| ConvertTo-Json -Compress"
     )
@@ -80,6 +81,13 @@ def test_configures_inherited_rmantree(tmp_path):
     result = _run_script(root, rman=rman)
 
     path = result["Path"].split(os.pathsep)
+    if os.name == "nt":
+        loader_path = path
+    elif sys.platform == "darwin":
+        loader_path = result["DyldLibraryPath"].split(os.pathsep)
+    else:
+        loader_path = result["LdLibraryPath"].split(os.pathsep)
     assert result["RenderMan"] == str(rman)
     assert str(rman / "bin") in path
-    assert str(rman / "lib") in path
+    assert str(rman / "bin") in loader_path
+    assert str(rman / "lib") in loader_path

--- a/tests/unit/test_openusd_env_shell.py
+++ b/tests/unit/test_openusd_env_shell.py
@@ -1,0 +1,164 @@
+"""Tests for the Bash/Zsh OpenUSD environment activator."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "openusd_env.sh"
+RUNNER = Path(__file__).parents[2] / "scripts" / "run_with_openusd.py"
+WSL = shutil.which("wsl.exe")
+BASH = shutil.which("bash")
+
+
+def _pxr_package(path: Path) -> Path:
+    (path / "pxr").mkdir(parents=True)
+    (path / "pxr" / "__init__.py").touch()
+    return path
+
+
+def _shell_path(path: Path) -> str:
+    if os.name != "nt":
+        return str(path)
+    if WSL is None:
+        pytest.skip("WSL is unavailable")
+    result = subprocess.run(
+        [WSL, "--distribution", "Ubuntu", "--exec", "wslpath", "-a", str(path)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _bash(command: str, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    if os.name == "nt":
+        if WSL is None:
+            pytest.skip("WSL is unavailable")
+        invocation = [
+            WSL,
+            "--distribution",
+            "Ubuntu",
+            "--exec",
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            command,
+        ]
+    else:
+        if BASH is None:
+            pytest.skip("Bash is unavailable")
+        invocation = [BASH, "--noprofile", "--norc", "-c", command]
+    return subprocess.run(invocation, text=True, capture_output=True, check=check)
+
+
+def _read_environment(command: str) -> dict[str, str]:
+    result = _bash(
+        f"unset PYTHONPATH LD_LIBRARY_PATH RMANTREE; {command}; "
+        "printf 'PYTHONPATH=%s\\nLD_LIBRARY_PATH=%s\\nRMANTREE=%s\\nPYTHON=%s\\n' "
+        '"$PYTHONPATH" "$LD_LIBRARY_PATH" "$RMANTREE" '
+        '"$OPENUSDCONNECT_PYTHON_EXECUTABLE"'
+    )
+    return dict(line.split("=", 1) for line in result.stdout.splitlines())
+
+
+def test_discovers_posix_prefix_with_spaces(tmp_path):
+    root = tmp_path / "OpenUSD install"
+    python_path = _pxr_package(root / "lib" / "python3.13" / "site-packages")
+    (root / "bin").mkdir(parents=True)
+    (root / "lib64").mkdir()
+    command = f"source {shlex.quote(_shell_path(SCRIPT))} {shlex.quote(_shell_path(root))}"
+
+    result = _read_environment(command)
+
+    assert result["PYTHONPATH"].split(":")[0] == _shell_path(python_path)
+    assert result["LD_LIBRARY_PATH"].split(":")[:2] == [
+        _shell_path(root / "lib"),
+        _shell_path(root / "lib64"),
+    ]
+    assert result["PYTHON"].startswith("/usr/bin/python3")
+
+
+def test_accepts_external_bindings_and_inherited_rmantree(tmp_path):
+    root = tmp_path / "OpenUSDInstall"
+    root.mkdir()
+    python_path = _pxr_package(
+        tmp_path / "OpenUSD" / ".venv" / "lib" / "python3.13" / "site-packages"
+    )
+    rman = tmp_path / "RenderMan Pro Server"
+    (rman / "bin").mkdir(parents=True)
+    (rman / "lib").mkdir()
+    command = (
+        f"export RMANTREE={shlex.quote(_shell_path(rman))}; "
+        f"source {shlex.quote(_shell_path(SCRIPT))} {shlex.quote(_shell_path(root))} "
+        f"--python-path {shlex.quote(_shell_path(python_path))}"
+    )
+
+    result = _read_environment(command)
+
+    assert result["PYTHONPATH"].split(":")[0] == _shell_path(python_path)
+    assert result["RMANTREE"] == _shell_path(rman)
+    assert result["LD_LIBRARY_PATH"].split(":")[:2] == [
+        _shell_path(rman / "bin"),
+        _shell_path(rman / "lib"),
+    ]
+
+
+def test_invalid_prefix_fails_without_applying_environment(tmp_path):
+    missing = _shell_path(tmp_path / "missing")
+    script = _shell_path(SCRIPT)
+
+    result = _bash(
+        f"unset OPENUSDCONNECT_USD_ROOT; source {shlex.quote(script)} {shlex.quote(missing)}; "
+        "status=$?; printf 'status=%s root=%s\\n' \"$status\" "
+        '"${OPENUSDCONNECT_USD_ROOT-}"',
+        check=False,
+    )
+
+    assert "status=2 root=" in result.stdout
+    assert "OpenUSD root does not exist" in result.stderr
+
+
+def test_adapter_rejects_direct_execution(tmp_path):
+    root = tmp_path / "OpenUSD"
+    _pxr_package(root / "lib" / "python3.13" / "site-packages")
+
+    result = _bash(
+        f"bash {shlex.quote(_shell_path(SCRIPT))} {shlex.quote(_shell_path(root))}",
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "must be sourced" in result.stderr
+
+
+def test_command_wrapper_runs_with_posix_environment(tmp_path):
+    root = tmp_path / "OpenUSD"
+    python_path = _pxr_package(root / "lib" / "python3.13" / "site-packages")
+    (root / "lib64").mkdir()
+    code = (
+        "import os; "
+        "print(os.environ['PYTHONPATH']); "
+        "print(os.environ['LD_LIBRARY_PATH'])"
+    )
+    command = (
+        "unset PYTHONPATH LD_LIBRARY_PATH RMANTREE; "
+        f"python3 {shlex.quote(_shell_path(RUNNER))} "
+        f"--usd-root {shlex.quote(_shell_path(root))} -- "
+        f"python3 -c {shlex.quote(code)}"
+    )
+
+    result = _bash(command)
+
+    lines = result.stdout.splitlines()
+    assert lines[-2] == _shell_path(python_path)
+    assert lines[-1].split(":") == [
+        _shell_path(root / "lib"),
+        _shell_path(root / "lib64"),
+    ]

--- a/tests/unit/test_openusd_env_shell.py
+++ b/tests/unit/test_openusd_env_shell.py
@@ -17,8 +17,13 @@ BASH = shutil.which("bash")
 
 
 def _pxr_package(path: Path) -> Path:
-    (path / "pxr").mkdir(parents=True)
-    (path / "pxr" / "__init__.py").touch()
+    pkg = path / "pxr"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+    (pkg / "Tf").mkdir()
+    (pkg / "Tf" / "__init__.py").touch()
+    (pkg / "Usd").mkdir()
+    (pkg / "Usd" / "__init__.py").write_text("def GetVersion():\n    return (0, 0, 0)\n")
     return path
 
 

--- a/tests/unit/test_openusd_env_shell.py
+++ b/tests/unit/test_openusd_env_shell.py
@@ -60,10 +60,14 @@ def _bash(command: str, *, check: bool = True) -> subprocess.CompletedProcess[st
 
 def _read_environment(command: str) -> dict[str, str]:
     result = _bash(
+        "unset OPENUSDCONNECT_ENV_PYTHON; "
+        "EXPECTED_PYTHON=$(python3 -c 'from pathlib import Path; import sys; "
+        "print(Path(sys.executable).resolve())'); "
         f"unset PYTHONPATH LD_LIBRARY_PATH RMANTREE; {command}; "
-        "printf 'PYTHONPATH=%s\\nLD_LIBRARY_PATH=%s\\nRMANTREE=%s\\nPYTHON=%s\\n' "
+        "printf 'PYTHONPATH=%s\\nLD_LIBRARY_PATH=%s\\nRMANTREE=%s\\nPYTHON=%s\\n"
+        "EXPECTED_PYTHON=%s\\n' "
         '"$PYTHONPATH" "$LD_LIBRARY_PATH" "$RMANTREE" '
-        '"$OPENUSDCONNECT_PYTHON_EXECUTABLE"'
+        '"$OPENUSDCONNECT_PYTHON_EXECUTABLE" "$EXPECTED_PYTHON"'
     )
     return dict(line.split("=", 1) for line in result.stdout.splitlines())
 
@@ -82,7 +86,7 @@ def test_discovers_posix_prefix_with_spaces(tmp_path):
         _shell_path(root / "lib"),
         _shell_path(root / "lib64"),
     ]
-    assert result["PYTHON"].startswith("/usr/bin/python3")
+    assert result["PYTHON"] == result["EXPECTED_PYTHON"]
 
 
 def test_accepts_external_bindings_and_inherited_rmantree(tmp_path):

--- a/tests/unit/test_run_with_openusd.py
+++ b/tests/unit/test_run_with_openusd.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from scripts import run_with_openusd
+from scripts import openusd_runtime, run_with_openusd
 
 
 def _usd_install(tmp_path):
@@ -16,6 +16,12 @@ def _usd_install(tmp_path):
     return root
 
 
+def _pxr_package(path):
+    (path / "pxr").mkdir(parents=True)
+    (path / "pxr" / "__init__.py").touch()
+    return path
+
+
 def test_build_environment_selects_project_runtime(tmp_path, monkeypatch):
     root = _usd_install(tmp_path)
     plugin = tmp_path / "plugins"
@@ -24,7 +30,7 @@ def test_build_environment_selects_project_runtime(tmp_path, monkeypatch):
     for path in (plugin, dll, rman / "bin", rman / "lib"):
         path.mkdir(parents=True)
 
-    monkeypatch.setattr(run_with_openusd, "_loader_path_key", lambda: "PATH")
+    monkeypatch.setattr(openusd_runtime, "_loader_path_key", lambda: "PATH")
     env, python_path = run_with_openusd.build_environment(
         root,
         base={"PATH": "existing", "PYTHONPATH": "existing-python"},
@@ -71,3 +77,81 @@ def test_build_environment_rejects_missing_plugin_path(tmp_path):
 
     with pytest.raises(RuntimeError, match="plugin path does not exist"):
         run_with_openusd.build_environment(root, plugin_paths=[tmp_path / "missing"])
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        ("Lib", "site-packages"),
+        ("lib", "python3.13", "site-packages"),
+        ("lib64", "python3.13", "dist-packages"),
+    ],
+)
+def test_build_environment_discovers_current_openusd_python_layouts(
+    tmp_path, relative_path
+):
+    root = tmp_path / "OpenUSD"
+    root.mkdir()
+    expected = _pxr_package(root.joinpath(*relative_path))
+
+    _, python_path = run_with_openusd.build_environment(root, base={})
+
+    assert python_path == expected
+
+
+def test_build_environment_accepts_python_bindings_outside_prefix(tmp_path):
+    root = tmp_path / "OpenUSD"
+    root.mkdir()
+    python_path = _pxr_package(tmp_path / "venv" / "Lib" / "site-packages")
+
+    env, selected = run_with_openusd.build_environment(
+        root, base={}, python_path=python_path
+    )
+
+    assert selected == python_path
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == str(python_path)
+
+
+def test_build_environment_uses_inherited_rmantree(tmp_path, monkeypatch):
+    root = _usd_install(tmp_path)
+    rman = tmp_path / "RenderMan"
+    (rman / "bin").mkdir(parents=True)
+    (rman / "lib").mkdir()
+    monkeypatch.setattr(openusd_runtime, "_loader_path_key", lambda: "PATH")
+
+    env, _ = run_with_openusd.build_environment(
+        root, base={"RMANTREE": str(rman), "PATH": "existing"}
+    )
+
+    assert env["RMANTREE"] == str(rman)
+    assert env["PATH"].split(os.pathsep)[:2] == [str(rman / "lib"), str(rman / "bin")]
+
+
+def test_build_environment_rejects_invalid_inherited_rmantree(tmp_path):
+    root = _usd_install(tmp_path)
+
+    with pytest.raises(RuntimeError, match="RenderMan root does not exist"):
+        run_with_openusd.build_environment(
+            root, base={"RMANTREE": str(tmp_path / "missing")}
+        )
+
+
+def test_build_environment_selects_python_executable(tmp_path):
+    root = _usd_install(tmp_path)
+    executable = tmp_path / "OpenUSD" / ".venv" / "Scripts" / "python.exe"
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+
+    env, _ = run_with_openusd.build_environment(
+        root, base={"PATH": "existing"}, python_executable=executable
+    )
+
+    assert env["OPENUSDCONNECT_PYTHON_EXECUTABLE"] == str(executable)
+    assert env["PATH"].split(os.pathsep)[0] == str(executable.parent)
+
+
+def test_environment_delta_contains_only_changes():
+    assert openusd_runtime.environment_delta(
+        {"PATH": "before", "UNCHANGED": "value"},
+        {"PATH": "after", "UNCHANGED": "value", "ADDED": "new"},
+    ) == {"PATH": "after", "ADDED": "new"}

--- a/tests/unit/test_run_with_openusd.py
+++ b/tests/unit/test_run_with_openusd.py
@@ -12,17 +12,25 @@ import pytest
 from scripts import openusd_runtime, run_with_openusd
 
 
+def _write_pxr(pkg):
+    """Create an importable pxr stub so the runtime binding check passes."""
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+    (pkg / "Tf").mkdir()
+    (pkg / "Tf" / "__init__.py").touch()
+    (pkg / "Usd").mkdir()
+    (pkg / "Usd" / "__init__.py").write_text("def GetVersion():\n    return (0, 0, 0)\n")
+
+
 def _usd_install(tmp_path):
     root = tmp_path / "OpenUSD"
-    (root / "lib" / "python" / "pxr").mkdir(parents=True)
-    (root / "lib" / "python" / "pxr" / "__init__.py").touch()
+    _write_pxr(root / "lib" / "python" / "pxr")
     (root / "bin").mkdir()
     return root
 
 
 def _pxr_package(path):
-    (path / "pxr").mkdir(parents=True)
-    (path / "pxr" / "__init__.py").touch()
+    _write_pxr(path / "pxr")
     return path
 
 
@@ -61,6 +69,7 @@ def test_main_forwards_command_and_exit_code(tmp_path, monkeypatch):
         return SimpleNamespace(returncode=7)
 
     monkeypatch.setattr(run_with_openusd.subprocess, "run", fake_run)
+    monkeypatch.setattr(run_with_openusd, "verify_bindings", lambda *a, **k: "0.0.0")
 
     result = run_with_openusd.main(
         ["--usd-root", str(root), "--", "python", "-c", "print('ok')"]
@@ -224,3 +233,71 @@ def test_environment_delta_contains_only_changes():
         {"PATH": "before", "UNCHANGED": "value"},
         {"PATH": "after", "UNCHANGED": "value", "ADDED": "new"},
     ) == {"PATH": "after", "ADDED": "new"}
+
+
+def test_verify_bindings_uses_selected_interpreter_and_environment(monkeypatch):
+    captured = {}
+
+    def fake_run(command, *, env, text, capture_output):
+        captured.update(command=command, env=env)
+        return SimpleNamespace(returncode=0, stdout="(0, 26, 11)\n", stderr="")
+
+    monkeypatch.setattr(openusd_runtime.subprocess, "run", fake_run)
+
+    version = openusd_runtime.verify_bindings(
+        {"PYTHONPATH": "bindings"},
+        "bindings",
+        python_executable=sys.executable,
+    )
+
+    assert version == "(0, 26, 11)"
+    assert captured["command"][0] == str(Path(sys.executable).resolve())
+    assert "from pxr import Tf, Usd" in captured["command"][-1]
+    assert captured["env"] == {"PYTHONPATH": "bindings"}
+
+
+def test_verify_bindings_reports_actionable_error_on_import_failure(monkeypatch):
+    def fake_run(command, *, env, text, capture_output):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="ImportError: DLL load failed while importing _tf",
+        )
+
+    monkeypatch.setattr(openusd_runtime.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        openusd_runtime.verify_bindings(
+            {}, "bindings", python_executable=sys.executable
+        )
+
+    message = str(excinfo.value)
+    assert "could not import OpenUSD" in message
+    assert "-PythonExecutable" in message
+    assert "_tf" in message
+
+
+def test_main_verifies_bindings_before_emitting_environment(tmp_path, monkeypatch):
+    root = _usd_install(tmp_path)
+    calls = {}
+
+    def fake_verify(env, python_path, python_executable):
+        calls.update(env=env, python_path=python_path)
+        return "0.0.0"
+
+    monkeypatch.setattr(openusd_runtime, "verify_bindings", fake_verify)
+
+    assert openusd_runtime.main(["--usd-root", str(root), "--format", "json"]) == 0
+    assert calls["python_path"] == root / "lib" / "python"
+
+
+def test_main_reports_verification_failure(tmp_path, monkeypatch, capsys):
+    root = _usd_install(tmp_path)
+
+    def fake_verify(*args, **kwargs):
+        raise RuntimeError("bindings could not be imported: boom")
+
+    monkeypatch.setattr(openusd_runtime, "verify_bindings", fake_verify)
+
+    assert openusd_runtime.main(["--usd-root", str(root), "--format", "json"]) == 2
+    assert "could not be imported" in capsys.readouterr().err

--- a/tests/unit/test_run_with_openusd.py
+++ b/tests/unit/test_run_with_openusd.py
@@ -1,6 +1,10 @@
 """Tests for the project OpenUSD command wrapper."""
 
+import json
 import os
+import subprocess
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -110,6 +114,64 @@ def test_build_environment_accepts_python_bindings_outside_prefix(tmp_path):
 
     assert selected == python_path
     assert env["PYTHONPATH"].split(os.pathsep)[0] == str(python_path)
+
+
+def test_build_environment_discovers_bindings_in_active_venv(tmp_path, monkeypatch):
+    root = tmp_path / "OpenUSDInstall"
+    root.mkdir()
+    python_path = _pxr_package(tmp_path / "OpenUSD" / ".venv" / "Lib" / "site-packages")
+    monkeypatch.setattr(
+        openusd_runtime,
+        "_active_venv_python_paths",
+        lambda: [python_path],
+    )
+
+    env, selected = run_with_openusd.build_environment(root, base={})
+
+    assert selected == python_path
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == str(python_path)
+
+
+def test_runtime_cli_discovers_bindings_from_real_active_venv(tmp_path):
+    root = tmp_path / "OpenUSDInstall"
+    root.mkdir()
+    venv = tmp_path / "OpenUSD" / ".venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(venv)],
+        check=True,
+    )
+    executable = venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    result = subprocess.run(
+        [
+            str(executable),
+            "-c",
+            "import sysconfig; print(sysconfig.get_path('purelib'))",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    python_path = _pxr_package(Path(result.stdout.strip()))
+    env = dict(os.environ)
+    env.update(PYTHONPATH="", RMANTREE="")
+
+    result = subprocess.run(
+        [
+            str(executable),
+            str(openusd_runtime.__file__),
+            "--usd-root",
+            str(root),
+            "--format",
+            "json",
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    configuration = json.loads(result.stdout)
+
+    assert configuration["python_path"] == str(python_path)
 
 
 def test_build_environment_uses_inherited_rmantree(tmp_path):

--- a/tests/unit/test_run_with_openusd.py
+++ b/tests/unit/test_run_with_openusd.py
@@ -112,19 +112,26 @@ def test_build_environment_accepts_python_bindings_outside_prefix(tmp_path):
     assert env["PYTHONPATH"].split(os.pathsep)[0] == str(python_path)
 
 
-def test_build_environment_uses_inherited_rmantree(tmp_path, monkeypatch):
+def test_build_environment_uses_inherited_rmantree(tmp_path):
     root = _usd_install(tmp_path)
     rman = tmp_path / "RenderMan"
     (rman / "bin").mkdir(parents=True)
     (rman / "lib").mkdir()
-    monkeypatch.setattr(openusd_runtime, "_loader_path_key", lambda: "PATH")
+    loader_key = openusd_runtime._loader_path_key()
+    base = {"RMANTREE": str(rman), "PATH": "existing"}
+    if loader_key != "PATH":
+        base[loader_key] = "existing-loader"
 
-    env, _ = run_with_openusd.build_environment(
-        root, base={"RMANTREE": str(rman), "PATH": "existing"}
-    )
+    env, _ = run_with_openusd.build_environment(root, base=base)
 
     assert env["RMANTREE"] == str(rman)
-    assert env["PATH"].split(os.pathsep)[:2] == [str(rman / "lib"), str(rman / "bin")]
+    assert str(rman / "bin") in env["PATH"].split(os.pathsep)
+    expected_loader_prefix = (
+        [str(rman / "lib"), str(rman / "bin")]
+        if os.name == "nt"
+        else [str(rman / "bin"), str(rman / "lib")]
+    )
+    assert env[loader_key].split(os.pathsep)[:2] == expected_loader_prefix
 
 
 def test_build_environment_rejects_invalid_inherited_rmantree(tmp_path):


### PR DESCRIPTION
- centralize OpenUSD, Python, plugin, DLL, and RenderMan path discovery
- add thin PowerShell and Bash/Zsh activation adapters
- support modern, legacy, venv-prefix, and external Python binding layouts
- select the matching Python executable for generated OpenUSD launchers
- configure platform-specific native library search paths
- update the command wrapper to use the shared resolver
- document Windows, Linux, macOS, venv, and hdPrman setup flows
- add Windows and WSL coverage for activation, quoting, validation, and failures