### PR TITLE
feat(client): support native-scene adapters in UsdReceiver

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,8 +38,8 @@ linked from the shorter workflow guides.
 
 ## Extend
 
-- [USD-native Python API](usd-native-integration.md): lifecycle, stage
-  ownership, managed clients, publishers, receivers, and resolver behavior.
+- [Python client and host-integration API](usd-native-integration.md): lifecycle,
+  stage ownership, native adapters, publishers, receivers, and resolver behavior.
 - [Shared stage architecture](shared-stage-architecture.md): exact file-layer
   synchronization and its protocol.
 - [MCP integration layout](../integrations/mcp/README.md#layout): extension

--- a/docs/usd-native-integration.md
+++ b/docs/usd-native-integration.md
@@ -1,4 +1,4 @@
-# USD-native Python API
+# Python client and host-integration API
 
 These APIs attach OpenUSDConnect to an application-owned `pxr.Usd.Stage`.
 Network I/O runs on background threads. Stage mutation does not: the
@@ -9,7 +9,7 @@ application must call `update()` from the stage-owning thread.
 | API | Direction | Layer model | Typical use |
 | --- | --- | --- | --- |
 | `ManagedClient` | Bidirectional | Server-owned collaboration layers plus one client-owned authoring layer | USD editor or DCC integration |
-| `UsdReceiver` | Receive | Server-owned collaboration layers | Viewer or read-only service |
+| `UsdReceiver` | Receive | Server-owned collaboration layers | USD viewer or `DCCAdapter`-backed native scene |
 | `UsdPublisher` | Send | Current edit-target layer | Producer with a separate receive stage, or send-only tool |
 | `SharedStageClient` | Bidirectional | Existing portable root and recursive sublayers | Exact production-layer editing |
 
@@ -47,6 +47,10 @@ All high-level clients use the same lifecycle:
 or `CLOSED`. Bidirectional applications should enable editing only in `READY`.
 The directional connection fields distinguish partial connectivity from a
 role that is not present.
+
+An adapter-backed `UsdReceiver` also enters `RECOVERY_REQUIRED` when resolver
+recomposition makes incremental projection unsafe. Rebuild the native scene,
+then call `acknowledge_native_scene_rebuilt()`.
 
 `ManagedClient.update()` and `SharedStageClient.update()` return `SyncUpdate`:
 
@@ -97,6 +101,36 @@ Application callbacks such as `on_applied` and `on_applied_events` run inside
 `update()` on the calling thread. Transport callbacks, including token,
 metadata, and playback notifications, may run on a background connection
 thread and must be marshalled before touching a UI.
+
+### Receive into an application-owned scene
+
+For a host that does not use a `Usd.Stage` as its scene, pass a `DCCAdapter` to
+the same high-level receiver. The stage becomes a composition mirror; only the
+adapter mutates the host scene:
+
+```python
+from pxr import Usd
+
+from openusdconnect import UsdReceiver
+
+mirror_stage = Usd.Stage.Open("shot.usda")
+adapter = MyHostAdapter(document)
+
+with UsdReceiver(
+    mirror_stage,
+    app_name="my-host",
+    adapter=adapter,
+    on_resync=adapter.reset,
+) as client:
+    while application_is_running():
+        client.update()  # call from the host's scene/UI thread
+```
+
+The client owns transport, replay, logical collaboration layers, and composed
+projection. The integration owns the adapter's mapping to native objects,
+stable object identity, units and axes, undo policy, and UI-thread scheduling.
+It must open equivalent base content in the mirror so OpenUSD composition sees
+the same references and weaker opinions as other participants.
 
 ## Publish USD edits
 
@@ -194,6 +228,11 @@ without raising from an ordinary interactive `update()`. See
 [Client recovery](client-recovery.md) before designing the host UI.
 
 ## Adapter destination contract
+
+`DCCAdapter` is the receiving boundary for an application-owned scene. It is
+not the outbound document-change observer. A bidirectional host separately
+captures its native edits and publishes them, commonly through an authoring
+stage and `UsdPublisher`.
 
 Layered receivers always reconstruct authoritative state in a USD mirror. What
 happens next depends on `DCCAdapter.targets_stage()`:
@@ -296,10 +335,11 @@ dependencies.
 A context-only resolver remap is a special case for adapters targeting a
 non-USD native scene. It can recompose both the live and previous-state stages
 before projection observes the old topology. The dispatcher then sets
-`native_scene_rebuild_required` and stops incremental delivery. Recreate or
-rebind the receiver/dispatcher, or rebuild the native destination and call
-`acknowledge_native_scene_rebuilt()` before resuming. An ordinary reconnect
-does not clear this guard.
+`native_scene_rebuild_required` and stops incremental delivery. The high-level
+client exposes this through `client.native_scene_rebuild_required` and
+`client.status`. Rebuild the native destination and call
+`client.acknowledge_native_scene_rebuilt()` before resuming. An ordinary
+reconnect does not clear this guard.
 
 ## Identity and authentication
 
@@ -314,9 +354,11 @@ and use `on_token_issued` to integrate with a host-specific store.
 ## Low-level APIs
 
 `NoticeEmitter`, `EventSender`, `ReceiverThread`, and `EventDispatcher` remain
-public for custom scheduling, DCC adapters, and constrained flat snapshot
-continuation. `ReceiverThread` requests layered replay by default; passing
-`layered_replay=False` selects the single-layer flat contract.
+public for integrations whose scheduling or continuation requirements cannot
+use the high-level clients. `ReceiverThread` requests layered replay by default;
+passing `layered_replay=False` selects the single-layer flat contract. Ordinary
+native-scene integrations should use `UsdReceiver(adapter=...)` instead of
+assembling these components.
 
 Construct low-level objects directly. Components exposed by a high-level
 client are diagnostic handles; mutating them bypasses the wrapper's lifecycle

--- a/openusdconnect/usd_client.py
+++ b/openusdconnect/usd_client.py
@@ -265,7 +265,9 @@ class UsdReceiver:
             raise TypeError("UsdReceiver requires a Usd.Stage composition source")
         validate_layered_source(stage)
         self._stage = stage
-        if self._owns_stage_adapter:
+        if isinstance(self._dispatcher.adapter, UsdStageAdapter):
+            self._dispatcher.adapter.stage = stage
+        elif self._owns_stage_adapter:
             self._dispatcher.adapter = UsdStageAdapter(stage)
         self._dispatcher.mirror_stage = (
             None if self._dispatcher.adapter.targets_stage() is stage else stage

--- a/openusdconnect/usd_client.py
+++ b/openusdconnect/usd_client.py
@@ -23,7 +23,7 @@ from ._client_utils import (
     resolve_client_token,
     validate_layered_source,
 )
-from .adapters import UsdStageAdapter
+from .adapters import DCCAdapter, UsdStageAdapter
 from .client_id import make_stable_client_id
 from .coalescing import TransformCoalescingWindow
 from .dispatcher import AssetDependencyRefreshResult, EventDispatcher
@@ -46,10 +46,13 @@ _DEFAULT_PORT = 7200
 
 
 class UsdReceiver:
-    """Receive authoritative layered replay into one application-owned stage.
+    """Receive authoritative layered replay through a high-level lifecycle.
 
     ``start`` launches only the socket reader. ``update`` drains and applies
-    queued events synchronously and must run on the stage-owning thread.
+    queued events synchronously and must run on the stage- or scene-owning
+    thread. By default, events apply directly to ``stage``. Pass an external
+    ``DCCAdapter`` to keep ``stage`` as the composition mirror and project its
+    composed values into an application-owned scene.
     """
 
     def __init__(
@@ -64,6 +67,7 @@ class UsdReceiver:
         token: str | None = None,
         persist_token: bool = True,
         reconnect: bool = True,
+        adapter: DCCAdapter | None = None,
         on_imported: Callable[[list[str]], None] | None = None,
         on_resync: Callable[[], None] | None = None,
         on_applied: Callable[[list[str]], None] | None = None,
@@ -75,8 +79,11 @@ class UsdReceiver:
         on_token_issued: Callable[[str], None] | None = None,
     ):
         app_name = require_app_name(app_name)
-        adapter = UsdStageAdapter(stage)
+        if not isinstance(stage, Usd.Stage):
+            raise TypeError("UsdReceiver requires a Usd.Stage composition source")
         validate_layered_source(stage)
+        self._owns_stage_adapter = adapter is None
+        destination_adapter = adapter or UsdStageAdapter(stage)
         resolved_token = resolve_client_token(host, port, token, persist_token)
         self._stage = stage
         self._host = host
@@ -99,7 +106,8 @@ class UsdReceiver:
         )
         self._dispatcher = EventDispatcher(
             receiver=self._receiver,
-            adapter=adapter,
+            adapter=destination_adapter,
+            mirror_stage=(None if destination_adapter.targets_stage() is stage else stage),
             on_imported=on_imported,
             on_resync=on_resync,
             on_applied=on_applied,
@@ -110,7 +118,11 @@ class UsdReceiver:
 
     @property
     def stage(self) -> Usd.Stage | None:
-        """Application-owned stage receiving authoritative changes, or ``None`` while parked."""
+        """Composition stage receiving authoritative changes, or ``None`` while parked.
+
+        With an external adapter this is the receiver's USD mirror, not the
+        adapter-owned destination scene.
+        """
         return self._stage
 
     @property
@@ -120,6 +132,8 @@ class UsdReceiver:
             phase = ClientPhase.CLOSED
         elif self.auth_rejected or self.connection_rejected:
             phase = ClientPhase.REJECTED
+        elif self.native_scene_rebuild_required:
+            phase = ClientPhase.RECOVERY_REQUIRED
         elif self.synchronized:
             phase = ClientPhase.READY
         elif self.connected:
@@ -133,7 +147,11 @@ class UsdReceiver:
             connected=self.connected,
             synchronized=self.synchronized,
             receiver_connected=self._receiver.connected,
-            reason=self._receiver.rejection_reason,
+            reason=(
+                "the adapter-owned scene must be rebuilt after resolver recomposition"
+                if self.native_scene_rebuild_required
+                else self._receiver.rejection_reason
+            ),
         )
 
     @property
@@ -177,6 +195,11 @@ class UsdReceiver:
     @property
     def pending_asset_dependencies(self) -> tuple[str, ...]:
         return self._dispatcher.pending_asset_dependencies
+
+    @property
+    def native_scene_rebuild_required(self) -> bool:
+        """Whether an external adapter destination needs a complete rebuild."""
+        return self._dispatcher.native_scene_rebuild_required
 
     def start(self) -> UsdReceiver:
         """Start the background socket reader and return this receiver."""
@@ -226,11 +249,11 @@ class UsdReceiver:
         return self._dispatcher.drain_and_apply(max_messages=max_messages)
 
     def rebind_stage(self, stage: Usd.Stage | None) -> None:
-        """Move receive-side application and managed layers to a new stage.
+        """Move receive-side composition and managed layers to a new stage.
 
         Pass ``None`` to park: the receiver stays connected and the queue
         continues to fill, but ``update()`` returns zero until a new stage
-        is bound.
+        is bound. A caller-provided external adapter remains attached.
         """
         if self._closed:
             raise RuntimeError("UsdReceiver is closed")
@@ -238,10 +261,15 @@ class UsdReceiver:
             self._stage = None
             self._dispatcher.unbind_stage()
             return
-        adapter = UsdStageAdapter(stage)
+        if not isinstance(stage, Usd.Stage):
+            raise TypeError("UsdReceiver requires a Usd.Stage composition source")
         validate_layered_source(stage)
         self._stage = stage
-        self._dispatcher.adapter = adapter
+        if self._owns_stage_adapter:
+            self._dispatcher.adapter = UsdStageAdapter(stage)
+        self._dispatcher.mirror_stage = (
+            None if self._dispatcher.adapter.targets_stage() is stage else stage
+        )
         self._dispatcher.bind_layered_stage(stage)
 
     def refresh_asset_dependency(
@@ -252,6 +280,12 @@ class UsdReceiver:
         if self._closed:
             raise RuntimeError("UsdReceiver is closed")
         return self._dispatcher.refresh_asset_dependency(asset_path)
+
+    def acknowledge_native_scene_rebuilt(self) -> None:
+        """Resume projection after rebuilding an external adapter destination."""
+        if self._closed:
+            raise RuntimeError("UsdReceiver is closed")
+        self._dispatcher.acknowledge_native_scene_rebuilt()
 
     def close(self) -> None:
         """Stop networking and release receiver-owned collaboration layers."""

--- a/tests/unit/test_usd_client.py
+++ b/tests/unit/test_usd_client.py
@@ -11,6 +11,7 @@ from openusdconnect import (
     RecoveryError,
     SyncUpdate,
     TransactionFailure,
+    UsdStageAdapter,
 )
 from openusdconnect import coalescing as coalescing_module
 from openusdconnect.codec import TransactionRejectionCode
@@ -174,6 +175,71 @@ def test_receiver_owns_external_adapter_projection_lifecycle():
         assert receiver.stage is replacement
         assert receiver._dispatcher.adapter is adapter
         assert receiver._dispatcher.mirror_stage is replacement
+    finally:
+        receiver.close()
+
+
+def test_receiver_rebinds_an_explicit_usd_stage_adapter():
+    original = Usd.Stage.CreateInMemory()
+    adapter = UsdStageAdapter(original)
+    receiver = UsdReceiver(
+        original,
+        app_name="explicit-stage-adapter",
+        adapter=adapter,
+        persist_token=False,
+        reconnect=False,
+    )
+    try:
+        replacement = Usd.Stage.CreateInMemory()
+        receiver.rebind_stage(replacement)
+
+        assert receiver._dispatcher.adapter is adapter
+        assert adapter.targets_stage() is replacement
+        assert receiver._dispatcher.mirror_stage is None
+
+        adapter.ensure_prim("/World/Rebound", "Xform")
+        assert replacement.GetPrimAtPath("/World/Rebound")
+        assert not original.GetPrimAtPath("/World/Rebound")
+    finally:
+        receiver.close()
+
+
+def test_receiver_surfaces_and_acknowledges_native_scene_rebuild():
+    class _ProjectionState:
+        native_scene_rebuild_required = True
+
+        def __init__(self):
+            self.acknowledgements = 0
+
+        def acknowledge_native_scene_rebuilt(self):
+            self.acknowledgements += 1
+            self.native_scene_rebuild_required = False
+
+        def close(self):
+            pass
+
+    receiver = UsdReceiver(
+        Usd.Stage.CreateInMemory(),
+        app_name="native-scene-recovery",
+        adapter=MockAdapter(),
+        persist_token=False,
+        reconnect=False,
+    )
+    state = _ProjectionState()
+    receiver._dispatcher._projection_state = state
+    receiver._started = True
+    receiver._receiver.connected = True
+    receiver._receiver._synchronized_event.set()
+    try:
+        assert receiver.native_scene_rebuild_required
+        assert receiver.status.phase is ClientPhase.RECOVERY_REQUIRED
+        assert "must be rebuilt" in receiver.status.reason
+
+        receiver.acknowledge_native_scene_rebuilt()
+
+        assert state.acknowledgements == 1
+        assert not receiver.native_scene_rebuild_required
+        assert receiver.status.phase is ClientPhase.READY
     finally:
         receiver.close()
 

--- a/tests/unit/test_usd_client.py
+++ b/tests/unit/test_usd_client.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import pytest
 from pxr import Sdf, Usd, UsdGeom
 
-from openusdconnect import ClientPhase, RecoveryError, SyncUpdate, TransactionFailure
+from openusdconnect import (
+    ClientPhase,
+    MockAdapter,
+    RecoveryError,
+    SyncUpdate,
+    TransactionFailure,
+)
 from openusdconnect import coalescing as coalescing_module
 from openusdconnect.codec import TransactionRejectionCode
 from openusdconnect.managed_client import ManagedClient
@@ -143,6 +149,31 @@ def test_receiver_update_forwards_message_budget(monkeypatch):
 
         assert receiver.update(max_messages=128) == 3
         assert calls == [128]
+    finally:
+        receiver.close()
+
+
+def test_receiver_owns_external_adapter_projection_lifecycle():
+    mirror = Usd.Stage.CreateInMemory()
+    adapter = MockAdapter()
+    receiver = UsdReceiver(
+        mirror,
+        app_name="native-scene-receiver",
+        adapter=adapter,
+        persist_token=False,
+        reconnect=False,
+    )
+    try:
+        assert receiver.stage is mirror
+        assert receiver._dispatcher.adapter is adapter
+        assert receiver._dispatcher.mirror_stage is mirror
+
+        replacement = Usd.Stage.CreateInMemory()
+        receiver.rebind_stage(replacement)
+
+        assert receiver.stage is replacement
+        assert receiver._dispatcher.adapter is adapter
+        assert receiver._dispatcher.mirror_stage is replacement
     finally:
         receiver.close()
 


### PR DESCRIPTION
- project composed mirror state through an optional DCCAdapter
- preserve external adapters across stage rebinds
- surface resolver-triggered native-scene rebuild recovery on UsdReceiver
- document and test the adapter-backed receiver lifecycle