### PR TITLE
feat(examples): add Qt native-scene integration demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Do not add `bundled-usd` when using the project runtime path above.
 | usdview plugin | Receive | [usdview guide](integrations/usdview/README.md) |
 | Unreal Engine plugin | Bidirectional, currently flat receive | [Unreal guide](integrations/unreal/OpenUSDConnect/README.md) |
 | Python / OpenUSD | Bidirectional | [USD-native API guide](docs/usd-native-integration.md) |
+| Custom native scene | Receive | [Qt integration example](examples/qt_native_viewer/README.md) |
 | MCP server | Author and inspect | `uv run --group mcp python -m integrations.mcp`; [MCP guide](docs/mcp-server-usage.md) |
 | Dashboard | Observe and administer | `uv run --group dashboard python scripts/demo_layer_dashboard.py` |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ linked from the shorter workflow guides.
 | Install and operate the Blender addon | [Blender addon usage](blender-addon-usage.md) |
 | Connect Pixar's reference USD viewer | [usdview integration](../integrations/usdview/README.md) |
 | Install and operate the Unreal Engine plugin | [Unreal Engine plugin](../integrations/unreal/OpenUSDConnect/README.md) |
+| Build an integration for an application-owned scene | [Qt native-scene example](../examples/qt_native_viewer/README.md) |
 | Author and inspect scenes through an MCP client | [MCP server usage](mcp-server-usage.md) |
 | Work with synchronized materials and shaders | [Live material editing](live-material-editing.md) |
 

--- a/docs/usd-native-integration.md
+++ b/docs/usd-native-integration.md
@@ -251,6 +251,13 @@ Native projection can express only the adapter event vocabulary. Generic Sdf
 opinions remain correct in the mirror even when the native scene has no
 equivalent operation.
 
+The [Qt native-scene example](../examples/qt_native_viewer/README.md) shows this
+receive path in a standalone application. `UsdReceiver` maintains the USD
+composition mirror and delivers composed changes to a `DCCAdapter`; the
+viewport reads only the adapter-owned scene. To adapt the example for another
+host, replace `NativeSceneAdapter`'s in-memory mutations with calls to the host
+scene API and run `client.update()` from the thread that owns that scene.
+
 ## Shared authored-layer editing
 
 `SharedStageClient` synchronizes authored state in an existing portable root

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,7 @@ stops its temporary server and clients and removes its temporary event log.
 | Example | What it demonstrates | Launcher |
 | --- | --- | --- |
 | [USD-native clients](usd_native_client/README.md) | Bounded headless publish-and-receive test; usdview is optional | [run.py](usd_native_client/run.py) |
+| [Qt native-scene integration](qt_native_viewer/README.md) | Receive composed changes through `DCCAdapter` and render an application-owned scene | [run.py](qt_native_viewer/run.py) |
 | [Fourier waves](fourier_waves/README.md#quickstart) | A compute client expands a procedural into live mesh geometry; runs until `Ctrl+C` | [run.py](fourier_waves/run.py) |
 | [Instancing dance](instancing_dance/README.md#quickstart) | Scenegraph instances, references, and animated transforms; runs until `Ctrl+C` | [run.py](instancing_dance/run.py) |
 

--- a/examples/qt_native_viewer/README.md
+++ b/examples/qt_native_viewer/README.md
@@ -1,0 +1,80 @@
+# Qt native-scene integration
+
+This example receives layered USD changes into an application-owned scene.
+`UsdReceiver` maintains a USD stage for composition and sends composed changes
+to `NativeSceneAdapter`. The Qt viewport renders the adapter-owned scene and
+never reads the USD stage.
+
+`NativeSceneAdapter` implements `DCCAdapter` by updating a small Python scene
+graph. Its methods show where a host would create objects, apply transforms and
+geometry state, update materials, or remove objects. The renderer uses the
+object lifecycle, transform, and display-color state needed by this demo.
+
+Run the complete example from the repository root:
+
+```text
+uv run --group bundled-usd --group qt-example python examples/qt_native_viewer/run.py
+```
+
+## Network flow
+
+The launcher starts a real OpenUSDConnect server with a temporary event log and
+connects three TCP clients: one viewer and two authors for the `animation` and
+`layout` departments. The server orders and persists their events, and the
+viewer receives the same layered replay used by other managed clients. There
+is no in-process shortcut between the authors and the adapter.
+
+`animation` is stronger than `layout`. After the connections are ready, the
+launcher runs four authored changes:
+
+1. Layout creates a blue cube at `x = -4`.
+2. Animation overrides it with an orange cube at `x = +4`.
+3. Layout changes its weaker opinion to `x = -1`. The canvas does not move and
+   no transform reaches the adapter because the composed value remains `+4`.
+4. Animation removes its prim spec. The layout value is revealed and projection
+   moves the native cube to `x = -1`.
+
+Use **Run masking demo** to repeat the sequence. Close the window to stop the
+temporary server and remove its event log.
+
+Drag with the left mouse button to orbit, drag with the right or middle button
+to pan, and use the wheel to zoom.
+
+For an unattended smoke run, use `--exit-after 6`. The last line should report
+`final native translation=[-1.0, 0.0, 0.0]`.
+
+## Integration boundary
+
+The receive-side integration is in `viewer.py`. `demo_driver.py` only authors
+the exact layer opinions used by the masking sequence.
+
+Connect the viewer to an existing server whose department priority includes
+`animation,layout`:
+
+```text
+uv run --group bundled-usd --group qt-example python examples/qt_native_viewer/viewer.py --port 7340
+```
+
+The reusable wiring in `MainWindow.__init__` is:
+
+```python
+mirror_stage = Usd.Stage.CreateInMemory()
+adapter = NativeSceneAdapter(native_scene)
+client = UsdReceiver(
+    mirror_stage,
+    app_name="my-native-host",
+    adapter=adapter,
+    on_resync=adapter.reset,
+)
+client.start()
+```
+
+Call `client.update()` from the thread that owns the host scene. Socket reads
+remain on the receiver's background thread; replay, USD composition, and
+projection happen when `update()` runs. `NativeSceneAdapter` requests one UI
+refresh after each applied batch rather than redrawing for every event.
+
+This example covers the receive path. A bidirectional host must also observe
+changes to its native document and publish equivalent USD edits. Use
+`UsdPublisher` when the integration maintains an authoring stage; otherwise,
+use the lower-level sending API to publish translated native events.

--- a/examples/qt_native_viewer/__init__.py
+++ b/examples/qt_native_viewer/__init__.py
@@ -1,0 +1,1 @@
+"""Qt example that projects composed USD state into a non-USD scene."""

--- a/examples/qt_native_viewer/demo_driver.py
+++ b/examples/qt_native_viewer/demo_driver.py
@@ -1,0 +1,108 @@
+"""Deterministic layer-authoring fixture for the native-scene viewer."""
+
+from __future__ import annotations
+
+import uuid
+
+from PySide6 import QtCore
+
+from openusdconnect import EventSender
+
+PRIM_PATH = "/World/ProjectionDemo"
+
+
+class ProjectionDemo(QtCore.QObject):
+    """Author two layer strengths so masking is visible in the adapter log."""
+
+    phase_changed = QtCore.Signal(str)
+
+    def __init__(self, host: str, port: int, parent=None):
+        super().__init__(parent)
+        run_id = uuid.uuid4().hex[:8]
+        self.layout = EventSender(
+            host,
+            port,
+            client_id=f"qt-layout-{run_id}",
+            origin=f"qt-layout-{run_id}",
+            department="layout",
+        )
+        self.animation = EventSender(
+            host,
+            port,
+            client_id=f"qt-animation-{run_id}",
+            origin=f"qt-animation-{run_id}",
+            department="animation",
+        )
+        if not self.layout.connect() or not self.animation.connect():
+            self.close()
+            raise ConnectionError("could not connect the projection demo authors")
+        self._timers: list[QtCore.QTimer] = []
+
+    @staticmethod
+    def _create_events(x: float, color: list[float]) -> list[dict]:
+        return [
+            {"k": "ensure_prim", "prim": PRIM_PATH, "typeName": "Cube"},
+            {"k": "ensure_xform_ops", "prim": PRIM_PATH},
+            {
+                "k": "set_xform_trs",
+                "prim": PRIM_PATH,
+                "fields": ["t"],
+                "t": [x, 0.0, 0.0],
+            },
+            {
+                "k": "set_gprim_attrs",
+                "prim": PRIM_PATH,
+                "attrs": {"displayColor": [color]},
+            },
+        ]
+
+    def _later(self, delay_ms: int, callback) -> None:
+        timer = QtCore.QTimer(self)
+        timer.setSingleShot(True)
+        timer.timeout.connect(callback)
+        timer.start(delay_ms)
+        self._timers.append(timer)
+
+    def run(self) -> None:
+        self.phase_changed.emit("Preparing the two collaboration layers")
+        self.animation.send_events([{"k": "delete_prim", "prim": PRIM_PATH}])
+        self.layout.send_events([{"k": "delete_prim", "prim": PRIM_PATH}])
+
+        def layout_authors() -> None:
+            self.phase_changed.emit("Layout authors x = -4 (visible)")
+            self.layout.send_events(self._create_events(-4.0, [0.12, 0.48, 1.0]))
+
+        def animation_overrides() -> None:
+            self.phase_changed.emit("Animation authors x = +4 (stronger layer wins)")
+            self.animation.send_events(self._create_events(4.0, [1.0, 0.32, 0.12]))
+
+        def layout_is_masked() -> None:
+            self.phase_changed.emit(
+                "Layout changes x to -1; composition is still +4, so no adapter event"
+            )
+            self.layout.send_events(
+                [
+                    {
+                        "k": "set_xform_trs",
+                        "prim": PRIM_PATH,
+                        "fields": ["t"],
+                        "t": [-1.0, 0.0, 0.0],
+                    }
+                ]
+            )
+
+        def reveal_layout() -> None:
+            self.phase_changed.emit("Animation removes its spec; projection reveals layout x = -1")
+            self.animation.send_events([{"k": "delete_prim", "prim": PRIM_PATH}])
+
+        self._later(300, layout_authors)
+        self._later(1500, animation_overrides)
+        self._later(2700, layout_is_masked)
+        self._later(3900, reveal_layout)
+
+    def close(self) -> None:
+        self.layout.disconnect()
+        self.animation.disconnect()
+
+
+__all__ = ["PRIM_PATH", "ProjectionDemo"]

--- a/examples/qt_native_viewer/empty.usda
+++ b/examples/qt_native_viewer/empty.usda
@@ -1,0 +1,10 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    metersPerUnit = 1
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+}

--- a/examples/qt_native_viewer/gl_viewport.py
+++ b/examples/qt_native_viewer/gl_viewport.py
@@ -1,0 +1,363 @@
+"""Interactive OpenGL viewport for the adapter-owned example scene."""
+
+from __future__ import annotations
+
+import math
+from array import array
+from dataclasses import dataclass
+
+from PySide6 import QtCore, QtGui
+from PySide6.QtOpenGL import (
+    QOpenGLBuffer,
+    QOpenGLShader,
+    QOpenGLShaderProgram,
+    QOpenGLVertexArrayObject,
+)
+from PySide6.QtOpenGLWidgets import QOpenGLWidget
+
+from examples.qt_native_viewer.native_scene import NativeObject, NativeScene
+
+_GL_COLOR_BUFFER_BIT = 0x00004000
+_GL_DEPTH_BUFFER_BIT = 0x00000100
+_GL_DEPTH_TEST = 0x0B71
+_GL_CULL_FACE = 0x0B44
+_GL_MULTISAMPLE = 0x809D
+_GL_FLOAT = 0x1406
+_GL_LINES = 0x0001
+_GL_TRIANGLES = 0x0004
+
+_VERTEX_SHADER = """
+#version 330 core
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 normal;
+
+uniform mat4 model;
+uniform mat4 mvp;
+
+out vec3 world_normal;
+
+void main()
+{
+    gl_Position = mvp * vec4(position, 1.0);
+    world_normal = mat3(model) * normal;
+}
+"""
+
+_FRAGMENT_SHADER = """
+#version 330 core
+in vec3 world_normal;
+
+uniform vec3 object_color;
+uniform int use_lighting;
+
+out vec4 fragment_color;
+
+void main()
+{
+    float intensity = 1.0;
+    if (use_lighting != 0) {
+        vec3 light_direction = normalize(vec3(-0.35, 0.8, 0.55));
+        intensity = 0.24 + 0.76 * max(dot(normalize(world_normal), light_direction), 0.0);
+    }
+    fragment_color = vec4(object_color * intensity, 1.0);
+}
+"""
+
+
+@dataclass(slots=True)
+class _Mesh:
+    buffer: QOpenGLBuffer
+    vertex_array: QOpenGLVertexArrayObject
+    vertex_count: int
+    primitive: int
+
+
+def _append_vertex(values: array, position, normal) -> None:
+    values.extend((*position, *normal))
+
+
+def _cube_vertices() -> array:
+    values = array("f")
+    faces = (
+        ((1, 0, 0), ((0.5, -0.5, -0.5), (0.5, -0.5, 0.5), (0.5, 0.5, 0.5), (0.5, 0.5, -0.5))),
+        ((-1, 0, 0), ((-0.5, -0.5, 0.5), (-0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (-0.5, 0.5, 0.5))),
+        ((0, 1, 0), ((-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, 0.5))),
+        ((0, -1, 0), ((-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (0.5, -0.5, -0.5), (-0.5, -0.5, -0.5))),
+        ((0, 0, 1), ((0.5, -0.5, 0.5), (-0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5))),
+        ((0, 0, -1), ((-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, 0.5, -0.5))),
+    )
+    for normal, corners in faces:
+        for index in (0, 1, 2, 0, 2, 3):
+            _append_vertex(values, corners[index], normal)
+    return values
+
+
+def _sphere_vertices(latitude_segments: int = 18, longitude_segments: int = 28) -> array:
+    values = array("f")
+
+    def point(latitude: int, longitude: int) -> tuple[float, float, float]:
+        theta = math.pi * latitude / latitude_segments
+        phi = 2.0 * math.pi * longitude / longitude_segments
+        sin_theta = math.sin(theta)
+        return (
+            sin_theta * math.cos(phi),
+            math.cos(theta),
+            sin_theta * math.sin(phi),
+        )
+
+    for latitude in range(latitude_segments):
+        for longitude in range(longitude_segments):
+            corners = (
+                point(latitude, longitude),
+                point(latitude + 1, longitude),
+                point(latitude + 1, longitude + 1),
+                point(latitude, longitude + 1),
+            )
+            for index in (0, 1, 2, 0, 2, 3):
+                vertex = corners[index]
+                _append_vertex(values, vertex, vertex)
+    return values
+
+
+def _grid_vertices(extent: int = 12) -> array:
+    values = array("f")
+    normal = (0.0, 1.0, 0.0)
+    for step in range(-extent, extent + 1):
+        _append_vertex(values, (-extent, 0.0, step), normal)
+        _append_vertex(values, (extent, 0.0, step), normal)
+        _append_vertex(values, (step, 0.0, -extent), normal)
+        _append_vertex(values, (step, 0.0, extent), normal)
+    return values
+
+
+def _axis_vertices() -> array:
+    values = array("f")
+    normal = (0.0, 1.0, 0.0)
+    for endpoint in ((3.0, 0.0, 0.0), (0.0, 3.0, 0.0), (0.0, 0.0, 3.0)):
+        _append_vertex(values, (0.0, 0.0, 0.0), normal)
+        _append_vertex(values, endpoint, normal)
+    return values
+
+
+class NativeViewport(QOpenGLWidget):
+    """Perspective renderer driven only by :class:`NativeScene`."""
+
+    def __init__(self, scene: NativeScene, parent=None):
+        super().__init__(parent)
+        self.scene = scene
+        self.setMinimumSize(560, 440)
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
+        self._yaw = 42.0
+        self._pitch = 24.0
+        self._distance = 18.0
+        self._target = QtGui.QVector3D(0.0, 0.8, 0.0)
+        self._last_pointer: QtCore.QPointF | None = None
+        self._shader: QOpenGLShaderProgram | None = None
+        self._meshes: dict[str, _Mesh] = {}
+
+    def initializeGL(self) -> None:
+        functions = self.context().functions()
+        functions.glEnable(_GL_DEPTH_TEST)
+        functions.glEnable(_GL_CULL_FACE)
+        functions.glEnable(_GL_MULTISAMPLE)
+
+        shader = QOpenGLShaderProgram(self)
+        if not shader.addShaderFromSourceCode(QOpenGLShader.ShaderTypeBit.Vertex, _VERTEX_SHADER):
+            raise RuntimeError(f"vertex shader compilation failed: {shader.log()}")
+        if not shader.addShaderFromSourceCode(
+            QOpenGLShader.ShaderTypeBit.Fragment, _FRAGMENT_SHADER
+        ):
+            raise RuntimeError(f"fragment shader compilation failed: {shader.log()}")
+        if not shader.link():
+            raise RuntimeError(f"shader link failed: {shader.log()}")
+        self._shader = shader
+        self._meshes = {
+            "cube": self._create_mesh(_cube_vertices(), _GL_TRIANGLES),
+            "sphere": self._create_mesh(_sphere_vertices(), _GL_TRIANGLES),
+            "grid": self._create_mesh(_grid_vertices(), _GL_LINES),
+            "axes": self._create_mesh(_axis_vertices(), _GL_LINES),
+        }
+
+    def _create_mesh(self, values: array, primitive: int) -> _Mesh:
+        shader = self._shader
+        if shader is None:
+            raise RuntimeError("OpenGL shader is not initialized")
+        vertex_array = QOpenGLVertexArrayObject(self)
+        if not vertex_array.create():
+            raise RuntimeError("could not create an OpenGL vertex array")
+        buffer = QOpenGLBuffer(QOpenGLBuffer.Type.VertexBuffer)
+        if not buffer.create():
+            raise RuntimeError("could not create an OpenGL vertex buffer")
+
+        vertex_array.bind()
+        buffer.bind()
+        buffer.allocate(values.tobytes(), len(values) * values.itemsize)
+        shader.bind()
+        shader.enableAttributeArray(0)
+        shader.setAttributeBuffer(0, _GL_FLOAT, 0, 3, 6 * values.itemsize)
+        shader.enableAttributeArray(1)
+        shader.setAttributeBuffer(1, _GL_FLOAT, 3 * values.itemsize, 3, 6 * values.itemsize)
+        shader.release()
+        buffer.release()
+        vertex_array.release()
+        return _Mesh(buffer, vertex_array, len(values) // 6, primitive)
+
+    def resizeGL(self, width: int, height: int) -> None:
+        self.context().functions().glViewport(0, 0, width, max(height, 1))
+
+    def paintGL(self) -> None:
+        functions = self.context().functions()
+        background = self.palette().color(QtGui.QPalette.ColorRole.Base)
+        red, green, blue, alpha = background.getRgbF()
+        functions.glClearColor(red, green, blue, alpha)
+        functions.glClear(_GL_COLOR_BUFFER_BIT | _GL_DEPTH_BUFFER_BIT)
+        shader = self._shader
+        if shader is None:
+            return
+
+        projection = QtGui.QMatrix4x4()
+        projection.perspective(45.0, self.width() / max(self.height(), 1), 0.1, 500.0)
+        view = QtGui.QMatrix4x4()
+        view.lookAt(self._eye_position(), self._target, QtGui.QVector3D(0.0, 1.0, 0.0))
+
+        shader.bind()
+        identity = QtGui.QMatrix4x4()
+        grid_color = self.palette().color(QtGui.QPalette.ColorRole.Mid)
+        self._draw_mesh(
+            self._meshes["grid"],
+            identity,
+            projection,
+            view,
+            grid_color,
+            use_lighting=False,
+        )
+        axis_colors = (
+            QtGui.QColor(214, 72, 72),
+            QtGui.QColor(75, 190, 105),
+            QtGui.QColor(72, 125, 224),
+        )
+        axis_mesh = self._meshes["axes"]
+        axis_mesh.vertex_array.bind()
+        shader.setUniformValue("model", identity)
+        shader.setUniformValue("mvp", projection * view * identity)
+        shader.setUniformValue("use_lighting", 0)
+        for index, color in enumerate(axis_colors):
+            shader.setUniformValue("object_color", self._vector_color(color))
+            functions.glDrawArrays(_GL_LINES, index * 2, 2)
+        axis_mesh.vertex_array.release()
+
+        for obj in sorted(self.scene.objects.values(), key=lambda item: item.path):
+            if obj.path == "/World" or not obj.visible or not obj.active:
+                continue
+            model = self._model_matrix(obj)
+            mesh = self._meshes["sphere" if obj.type_name in {"Sphere", "Capsule"} else "cube"]
+            self._draw_mesh(
+                mesh,
+                model,
+                projection,
+                view,
+                self._object_color(obj),
+                use_lighting=True,
+            )
+        shader.release()
+
+    def _draw_mesh(
+        self,
+        mesh: _Mesh,
+        model: QtGui.QMatrix4x4,
+        projection: QtGui.QMatrix4x4,
+        view: QtGui.QMatrix4x4,
+        color: QtGui.QColor,
+        *,
+        use_lighting: bool,
+    ) -> None:
+        shader = self._shader
+        if shader is None:
+            return
+        shader.setUniformValue("model", model)
+        shader.setUniformValue("mvp", projection * view * model)
+        shader.setUniformValue("object_color", self._vector_color(color))
+        shader.setUniformValue("use_lighting", int(use_lighting))
+        mesh.vertex_array.bind()
+        self.context().functions().glDrawArrays(mesh.primitive, 0, mesh.vertex_count)
+        mesh.vertex_array.release()
+
+    @staticmethod
+    def _vector_color(color: QtGui.QColor) -> QtGui.QVector3D:
+        red, green, blue, _alpha = color.getRgbF()
+        return QtGui.QVector3D(red, green, blue)
+
+    @staticmethod
+    def _object_color(obj: NativeObject) -> QtGui.QColor:
+        colors = obj.attributes.get("displayColor") or []
+        if colors and len(colors[0]) >= 3:
+            rgb = [max(0.0, min(float(component), 1.0)) for component in colors[0][:3]]
+            return QtGui.QColor.fromRgbF(*rgb)
+        return QtGui.QColor(65, 145, 235)
+
+    @staticmethod
+    def _model_matrix(obj: NativeObject) -> QtGui.QMatrix4x4:
+        model = QtGui.QMatrix4x4()
+        model.translate(*(float(value) for value in obj.translation[:3]))
+        if len(obj.rotation) == 4:
+            w, x, y, z = (float(value) for value in obj.rotation)
+            model.rotate(QtGui.QQuaternion(w, x, y, z))
+        scale = [float(value) for value in obj.scale[:3]]
+        if obj.type_name in {"Sphere", "Capsule"}:
+            radius = float(obj.attributes.get("radius", 0.75))
+            scale = [component * radius for component in scale]
+        else:
+            size = float(obj.attributes.get("size", 1.5))
+            scale = [component * size for component in scale]
+        model.scale(*scale)
+        return model
+
+    def _eye_position(self) -> QtGui.QVector3D:
+        yaw = math.radians(self._yaw)
+        pitch = math.radians(self._pitch)
+        direction = QtGui.QVector3D(
+            math.cos(pitch) * math.sin(yaw),
+            math.sin(pitch),
+            math.cos(pitch) * math.cos(yaw),
+        )
+        return self._target + direction * self._distance
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:
+        self._last_pointer = event.position()
+        self.setFocus()
+
+    def mouseMoveEvent(self, event: QtGui.QMouseEvent) -> None:
+        if self._last_pointer is None:
+            return
+        delta = event.position() - self._last_pointer
+        self._last_pointer = event.position()
+        if event.buttons() & QtCore.Qt.MouseButton.LeftButton:
+            self._yaw -= delta.x() * 0.45
+            self._pitch = max(-85.0, min(85.0, self._pitch + delta.y() * 0.35))
+        elif event.buttons() & (
+            QtCore.Qt.MouseButton.MiddleButton | QtCore.Qt.MouseButton.RightButton
+        ):
+            yaw = math.radians(self._yaw)
+            right = QtGui.QVector3D(math.cos(yaw), 0.0, -math.sin(yaw))
+            up = QtGui.QVector3D(0.0, 1.0, 0.0)
+            scale = self._distance * 0.0018
+            self._target += right * (-delta.x() * scale) + up * (delta.y() * scale)
+        self.update()
+
+    def mouseReleaseEvent(self, _event: QtGui.QMouseEvent) -> None:
+        self._last_pointer = None
+
+    def wheelEvent(self, event: QtGui.QWheelEvent) -> None:
+        steps = event.angleDelta().y() / 120.0
+        self._distance = max(2.0, min(120.0, self._distance * math.pow(0.86, steps)))
+        self.update()
+
+    def mouseDoubleClickEvent(self, _event: QtGui.QMouseEvent) -> None:
+        self._yaw = 42.0
+        self._pitch = 24.0
+        self._distance = 18.0
+        self._target = QtGui.QVector3D(0.0, 0.8, 0.0)
+        self.update()
+
+
+__all__ = ["NativeViewport"]

--- a/examples/qt_native_viewer/native_scene.py
+++ b/examples/qt_native_viewer/native_scene.py
@@ -1,0 +1,391 @@
+"""Application-owned scene graph and direct ``DCCAdapter`` implementation.
+
+This module is deliberately independent of Qt. A host integration replaces
+``NativeScene`` mutations with calls into its own scene/object API while keeping
+the same adapter boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from openusdconnect import DCCAdapter
+
+
+def _plain_value(value):
+    """Detach numpy-backed receive values from the network decode buffer."""
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    if isinstance(value, dict):
+        return {key: _plain_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain_value(item) for item in value]
+    if isinstance(value, set):
+        return sorted(value)
+    return value
+
+
+@dataclass(slots=True)
+class NativeObject:
+    """State one external application might keep for a scene object."""
+
+    path: str
+    type_name: str = "Xform"
+    api_schemas: set[str] = field(default_factory=set)
+    xform_ready: bool = False
+    translation: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    rotation: list[float] = field(default_factory=lambda: [1.0, 0.0, 0.0, 0.0])
+    scale: list[float] = field(default_factory=lambda: [1.0, 1.0, 1.0])
+    transform_samples: dict[float, dict] = field(default_factory=dict)
+    visible: bool = True
+    visibility_samples: dict[float, bool] = field(default_factory=dict)
+    active: bool = True
+    attributes: dict = field(default_factory=dict)
+    attribute_samples: dict[float, dict] = field(default_factory=dict)
+    references: list = field(default_factory=list)
+    reference_list_op_authored: bool = False
+    reference_list_op_explicit: bool = False
+    payloads: list = field(default_factory=list)
+    payload_list_op_authored: bool = False
+    payload_list_op_explicit: bool = False
+    payload_loaded: bool = True
+    variant_selections: dict[str, str] = field(default_factory=dict)
+    material_bindings: dict[str, str] = field(default_factory=dict)
+    shader_id: str = ""
+    connectable_inputs: dict = field(default_factory=dict)
+    connectable_input_types: dict = field(default_factory=dict)
+    connectable_input_samples: dict[float, dict] = field(default_factory=dict)
+    connectable_connections: dict = field(default_factory=dict)
+    instanceable: bool = False
+    point_instancer: dict = field(default_factory=dict)
+    point_instancer_samples: dict[float, dict] = field(default_factory=dict)
+
+
+class NativeScene:
+    """Plain application scene with no USD stage as its backing store."""
+
+    def __init__(self):
+        self.objects: dict[str, NativeObject] = {}
+        self.stage_metadata: dict = {}
+        self.revision = 0
+
+    def ensure_object(self, path: str, type_name: str = "Xform") -> NativeObject:
+        obj = self.objects.get(path)
+        if obj is None:
+            obj = NativeObject(path=path, type_name=type_name or "Xform")
+            self.objects[path] = obj
+        return obj
+
+    def require_object(self, path: str, operation: str) -> NativeObject:
+        obj = self.objects.get(path)
+        if obj is None:
+            raise RuntimeError(f"{operation} requires an existing native object at {path}")
+        return obj
+
+    def delete_subtree(self, path: str) -> bool:
+        prefix = path.rstrip("/") + "/"
+        removed = [
+            candidate
+            for candidate in self.objects
+            if candidate == path or candidate.startswith(prefix)
+        ]
+        for candidate in removed:
+            del self.objects[candidate]
+        return bool(removed)
+
+    def rename_subtree(self, path: str, new_name: str) -> bool:
+        if path not in self.objects:
+            return False
+        if not new_name or "/" in new_name:
+            raise ValueError(f"invalid native object name {new_name!r}")
+        parent = path.rsplit("/", 1)[0]
+        new_root = f"{parent}/{new_name}"
+        prefix = path.rstrip("/") + "/"
+        moved = [
+            candidate
+            for candidate in self.objects
+            if candidate == path or candidate.startswith(prefix)
+        ]
+        destinations = {new_root + candidate[len(path) :] for candidate in moved}
+        collisions = destinations.intersection(self.objects).difference(moved)
+        if collisions:
+            raise RuntimeError(f"rename_prim would replace native objects: {sorted(collisions)!r}")
+        replacements = {}
+        for old_path in sorted(moved, key=lambda candidate: candidate.count("/")):
+            obj = self.objects.pop(old_path)
+            suffix = old_path[len(path) :]
+            obj.path = new_root + suffix
+            replacements[obj.path] = obj
+        self.objects.update(replacements)
+        return True
+
+    def clear(self) -> None:
+        self.objects.clear()
+        self.stage_metadata.clear()
+        self.revision += 1
+
+
+class NativeSceneAdapter(DCCAdapter):
+    """Reference adapter for an application with its own non-USD scene."""
+
+    def __init__(
+        self,
+        scene: NativeScene,
+        on_changed: Callable[[list[dict]], None] | None = None,
+    ):
+        self.scene = scene
+        self.on_changed = on_changed
+
+    def targets_stage(self):
+        """Select composed projection by declaring a non-USD destination."""
+        return None
+
+    def apply_events(self, events: list[dict]) -> int:
+        """Use public event dispatch, then refresh the host UI once per batch."""
+        count = super().apply_events(events)
+        self.scene.revision += 1
+        if self.on_changed is not None:
+            self.on_changed(events)
+        return count
+
+    def ensure_prim(
+        self,
+        prim_path: str,
+        type_name: str = "Xform",
+        api_schemas: list[str] | None = None,
+    ) -> bool:
+        obj = self.scene.ensure_object(prim_path, type_name)
+        obj.api_schemas.update(api_schemas or ())
+        return True
+
+    def ensure_xform_ops(self, prim_path: str) -> bool:
+        obj = self.scene.require_object(prim_path, "ensure_xform_ops")
+        # A real host folds any pre-transform/offset into its canonical local
+        # transform here. This scene already stores only canonical local TRS.
+        obj.xform_ready = True
+        return True
+
+    def set_xform_trs(
+        self,
+        prim_path: str,
+        *,
+        t: list[float] | None = None,
+        r: list[float] | None = None,
+        s: list[float] | None = None,
+        time: float | None = None,
+    ) -> bool:
+        obj = self.scene.require_object(prim_path, "set_xform_trs")
+        values = {
+            key: _plain_value(value)
+            for key, value in (("t", t), ("r", r), ("s", s))
+            if value is not None
+        }
+        if time is not None:
+            obj.transform_samples.setdefault(float(time), {}).update(values)
+            return True
+        if t is not None:
+            obj.translation = values["t"]
+        if r is not None:
+            obj.rotation = values["r"]
+        if s is not None:
+            obj.scale = values["s"]
+        return True
+
+    def delete_prim(self, prim_path: str) -> bool:
+        return self.scene.delete_subtree(prim_path)
+
+    def deactivate_prim(self, prim_path: str, active: bool = False) -> bool:
+        self.scene.require_object(prim_path, "deactivate_prim").active = bool(active)
+        return True
+
+    def rename_prim(self, prim_path: str, new_name: str) -> bool:
+        return self.scene.rename_subtree(prim_path, new_name)
+
+    def set_visibility(
+        self,
+        prim_path: str,
+        visible: bool,
+        time: float | None = None,
+    ) -> bool:
+        obj = self.scene.require_object(prim_path, "set_visibility")
+        if time is None:
+            obj.visible = bool(visible)
+        else:
+            obj.visibility_samples[float(time)] = bool(visible)
+        return True
+
+    def set_gprim_attrs(
+        self,
+        prim_path: str,
+        attrs: dict,
+        time: float | None = None,
+    ) -> bool:
+        obj = self.scene.require_object(prim_path, "set_gprim_attrs")
+        values = _plain_value(attrs)
+        if time is None:
+            obj.attributes.update(values)
+        else:
+            obj.attribute_samples.setdefault(float(time), {}).update(values)
+        return True
+
+    def set_reference(
+        self,
+        prim_path: str,
+        refs: list,
+        *,
+        list_op_authored: bool,
+        list_op_explicit: bool,
+    ) -> bool:
+        obj = self.scene.ensure_object(prim_path)
+        obj.references = _plain_value(refs)
+        obj.reference_list_op_authored = bool(list_op_authored)
+        obj.reference_list_op_explicit = bool(list_op_explicit)
+        return True
+
+    def set_payload(
+        self,
+        prim_path: str,
+        payloads: list,
+        *,
+        list_op_authored: bool,
+        list_op_explicit: bool,
+    ) -> bool:
+        obj = self.scene.ensure_object(prim_path)
+        obj.payloads = _plain_value(payloads)
+        obj.payload_list_op_authored = bool(list_op_authored)
+        obj.payload_list_op_explicit = bool(list_op_explicit)
+        return True
+
+    def load_payload(self, prim_path: str) -> bool:
+        self.scene.require_object(prim_path, "load_payload").payload_loaded = True
+        return True
+
+    def unload_payload(self, prim_path: str) -> bool:
+        self.scene.require_object(prim_path, "unload_payload").payload_loaded = False
+        return True
+
+    def set_variant_selections(self, prim_path: str, selections: dict[str, str]) -> bool:
+        obj = self.scene.ensure_object(prim_path)
+        obj.variant_selections = dict(selections)
+        return True
+
+    def set_material_binding(
+        self,
+        prim_path: str,
+        material_path: str,
+        material_purpose: str = "",
+    ) -> bool:
+        obj = self.scene.require_object(prim_path, "set_material_binding")
+        if material_path:
+            obj.material_bindings[material_purpose] = material_path
+        else:
+            obj.material_bindings.pop(material_purpose, None)
+        return True
+
+    def set_connectable_input(
+        self,
+        prim_path: str,
+        info_id: str,
+        inputs: dict,
+        input_types: dict,
+        time: float | None = None,
+    ) -> bool:
+        obj = self.scene.ensure_object(prim_path, "Shader" if info_id else "NodeGraph")
+        obj.shader_id = info_id
+        values = _plain_value(inputs)
+        if time is None:
+            obj.connectable_inputs.update(values)
+            obj.connectable_input_types.update(input_types)
+        else:
+            obj.connectable_input_samples.setdefault(float(time), {}).update(values)
+        return True
+
+    def set_connectable_connection(
+        self,
+        prim_path: str,
+        connections: dict,
+        disconnections: list | None = None,
+    ) -> bool:
+        obj = self.scene.ensure_object(prim_path, "Shader")
+        obj.connectable_connections.update(_plain_value(connections))
+        for name in disconnections or ():
+            obj.connectable_connections.pop(name, None)
+        return True
+
+    def set_stage_metadata(
+        self,
+        *,
+        timeCodesPerSecond: float | None = None,
+        framesPerSecond: float | None = None,
+        startTimeCode: float | None = None,
+        endTimeCode: float | None = None,
+        metersPerUnit: float | None = None,
+        upAxis: str | None = None,
+    ) -> bool:
+        values = {
+            "timeCodesPerSecond": timeCodesPerSecond,
+            "framesPerSecond": framesPerSecond,
+            "startTimeCode": startTimeCode,
+            "endTimeCode": endTimeCode,
+            "metersPerUnit": metersPerUnit,
+            "upAxis": upAxis,
+        }
+        self.scene.stage_metadata.update(
+            {key: value for key, value in values.items() if value is not None}
+        )
+        return True
+
+    def set_instanceable(self, prim_path: str, instanceable: bool) -> bool:
+        self.scene.require_object(prim_path, "set_instanceable").instanceable = bool(instanceable)
+        return True
+
+    def set_point_instancer(
+        self,
+        prim_path: str,
+        *,
+        prototypes: list[str] | None = None,
+        proto_indices=None,
+        positions=None,
+        orientations=None,
+        scales=None,
+        velocities=None,
+        accelerations=None,
+        angular_velocities=None,
+        ids=None,
+        invisible_ids=None,
+        inactive_ids=None,
+        time: float | None = None,
+    ) -> bool:
+        obj = self.scene.ensure_object(prim_path, "PointInstancer")
+        values = {
+            key: _plain_value(value)
+            for key, value in (
+                ("prototypes", prototypes),
+                ("proto_indices", proto_indices),
+                ("positions", positions),
+                ("orientations", orientations),
+                ("scales", scales),
+                ("velocities", velocities),
+                ("accelerations", accelerations),
+                ("angular_velocities", angular_velocities),
+                ("ids", ids),
+                ("invisible_ids", invisible_ids),
+                ("inactive_ids", inactive_ids),
+            )
+            if value is not None
+        }
+        if time is None:
+            obj.point_instancer.update(values)
+        else:
+            obj.point_instancer_samples.setdefault(float(time), {}).update(values)
+        return True
+
+    def reset(self) -> None:
+        """Clear application state before a complete authoritative replay."""
+        self.scene.clear()
+        if self.on_changed is not None:
+            self.on_changed([])
+
+
+__all__ = ["NativeObject", "NativeScene", "NativeSceneAdapter"]

--- a/examples/qt_native_viewer/run.py
+++ b/examples/qt_native_viewer/run.py
@@ -1,0 +1,101 @@
+"""Start a temporary server and the Qt native-scene projection example."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from examples.qt_native_viewer import viewer  # noqa: E402
+
+BASE_USD = Path(__file__).with_name("empty.usda")
+
+
+def _wait_for_port(host: str, port: int, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+def _terminate(process: subprocess.Popen | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=2)
+
+
+def _remove_log(path: Path) -> None:
+    for suffix in ("", "-wal", "-shm"):
+        try:
+            path.with_name(path.name + suffix).unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7340)
+    parser.add_argument(
+        "--exit-after",
+        type=float,
+        default=0.0,
+        help="close the viewer after this many seconds; zero waits for the window to close",
+    )
+    args = parser.parse_args()
+
+    descriptor, log_name = tempfile.mkstemp(prefix="qt_native_viewer_", suffix=".db")
+    os.close(descriptor)
+    log_path = Path(log_name)
+    server = None
+    try:
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "openusdconnect.server",
+                "--host",
+                args.host,
+                "--port",
+                str(args.port),
+                "--base",
+                str(BASE_USD),
+                "--departments",
+                "animation,layout",
+                "--event-log",
+                str(log_path),
+            ],
+            cwd=_REPO_ROOT,
+        )
+        if not _wait_for_port(args.host, args.port):
+            print("server did not become ready", file=sys.stderr)
+            return 1
+        viewer_args = ["--host", args.host, "--port", str(args.port), "--demo"]
+        if args.exit_after > 0:
+            viewer_args.extend(("--exit-after", str(args.exit_after)))
+        return viewer.main(viewer_args)
+    finally:
+        _terminate(server)
+        _remove_log(log_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/qt_native_viewer/viewer.py
+++ b/examples/qt_native_viewer/viewer.py
@@ -1,0 +1,158 @@
+"""Qt viewer backed by a non-USD scene graph populated through DCCAdapter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from pxr import Usd  # noqa: E402
+from PySide6 import QtCore, QtGui, QtWidgets  # noqa: E402
+
+from examples.qt_native_viewer.demo_driver import PRIM_PATH, ProjectionDemo  # noqa: E402
+from examples.qt_native_viewer.gl_viewport import NativeViewport  # noqa: E402
+from examples.qt_native_viewer.native_scene import NativeScene, NativeSceneAdapter  # noqa: E402
+from openusdconnect import UsdReceiver  # noqa: E402
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self, host: str, port: int, *, run_demo: bool):
+        super().__init__()
+        self.setWindowTitle("OpenUSDConnect native-scene projection")
+        self.resize(1040, 680)
+
+        self.native_scene = NativeScene()
+        self.adapter = NativeSceneAdapter(self.native_scene, self._on_native_events)
+        self.mirror_stage = Usd.Stage.CreateInMemory()
+        self.client = UsdReceiver(
+            self.mirror_stage,
+            app_name="qt-native-viewer",
+            host=host,
+            port=port,
+            adapter=self.adapter,
+            on_resync=self.adapter.reset,
+            persist_token=False,
+        )
+
+        self.viewport = NativeViewport(self.native_scene)
+        self.outliner = QtWidgets.QTreeWidget()
+        self.outliner.setHeaderLabels(["Native object", "Type", "Position"])
+        self.outliner.setAlternatingRowColors(True)
+        self.event_log = QtWidgets.QPlainTextEdit()
+        self.event_log.setReadOnly(True)
+        self.event_log.setPlaceholderText("Projected adapter events appear here")
+        self.phase_label = QtWidgets.QLabel("Waiting for composed state")
+        self.phase_label.setWordWrap(True)
+        self.run_button = QtWidgets.QPushButton("Run masking demo")
+
+        side = QtWidgets.QWidget()
+        side_layout = QtWidgets.QVBoxLayout(side)
+        side_layout.addWidget(QtWidgets.QLabel("Left drag: orbit · right drag: pan · wheel: zoom"))
+        side_layout.addWidget(QtWidgets.QLabel("Adapter-owned scene"))
+        side_layout.addWidget(self.outliner, 2)
+        side_layout.addWidget(QtWidgets.QLabel("Projected events"))
+        side_layout.addWidget(self.event_log, 3)
+        side_layout.addWidget(self.phase_label)
+        side_layout.addWidget(self.run_button)
+
+        splitter = QtWidgets.QSplitter()
+        splitter.addWidget(self.viewport)
+        splitter.addWidget(side)
+        splitter.setStretchFactor(0, 3)
+        splitter.setStretchFactor(1, 2)
+        self.setCentralWidget(splitter)
+
+        self.client.start()
+        self.demo_endpoint = (host, port)
+        self.demo: ProjectionDemo | None = None
+        self.run_button.clicked.connect(self._run_demo)
+        self.timer = QtCore.QTimer(self)
+        self.timer.timeout.connect(self._drain)
+        self.timer.start(16)
+        if run_demo:
+            QtCore.QTimer.singleShot(500, self._run_demo)
+
+    def _run_demo(self) -> None:
+        if self.demo is None:
+            try:
+                self.demo = ProjectionDemo(*self.demo_endpoint, self)
+            except (ConnectionError, OSError) as exc:
+                self.phase_label.setText(f"Could not start demo authors: {exc}")
+                return
+            self.demo.phase_changed.connect(self.phase_label.setText)
+        self.run_button.setEnabled(False)
+        self.demo.run()
+        QtCore.QTimer.singleShot(4500, lambda: self.run_button.setEnabled(True))
+
+    def _drain(self) -> None:
+        try:
+            self.client.update()
+        except Exception as exc:
+            self.timer.stop()
+            self.phase_label.setText(f"Receiver stopped: {exc}")
+
+    def _on_native_events(self, events: list[dict]) -> None:
+        self.outliner.clear()
+        for obj in sorted(self.native_scene.objects.values(), key=lambda item: item.path):
+            position = ", ".join(f"{value:.2f}" for value in obj.translation)
+            self.outliner.addTopLevelItem(
+                QtWidgets.QTreeWidgetItem([obj.path, obj.type_name, position])
+            )
+        if events:
+            self.event_log.appendPlainText(json.dumps(events, indent=2, default=str))
+        self.viewport.update()
+
+    def closeEvent(self, event) -> None:
+        self.timer.stop()
+        if self.demo is not None:
+            self.demo.close()
+        self.client.close()
+        super().closeEvent(event)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7340)
+    parser.add_argument("--demo", action="store_true", help="run the masking demo after startup")
+    parser.add_argument(
+        "--exit-after",
+        type=float,
+        default=0.0,
+        help="close after this many seconds; zero waits for the window to close",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    surface_format = QtGui.QSurfaceFormat()
+    surface_format.setRenderableType(QtGui.QSurfaceFormat.RenderableType.OpenGL)
+    surface_format.setProfile(QtGui.QSurfaceFormat.OpenGLContextProfile.CoreProfile)
+    surface_format.setVersion(3, 3)
+    surface_format.setSamples(4)
+    QtGui.QSurfaceFormat.setDefaultFormat(surface_format)
+    application = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv[:1])
+    try:
+        window = MainWindow(args.host, args.port, run_demo=args.demo)
+    except (ConnectionError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    window.show()
+    if args.exit_after > 0:
+        QtCore.QTimer.singleShot(round(args.exit_after * 1000), window.close)
+    result = application.exec()
+    if args.demo and args.exit_after > 0:
+        obj = window.native_scene.objects.get(PRIM_PATH)
+        translation = obj.translation if obj is not None else None
+        print(f"final native translation={translation}")
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ mcp = [
 profile = [
     "py-spy==0.4.2",
 ]
+qt-example = [
+    "PySide6-Essentials==6.11.1",
+]
 visual = [
     "flip-evaluator==1.7",
 ]

--- a/tests/unit/test_qt_native_viewer.py
+++ b/tests/unit/test_qt_native_viewer.py
@@ -1,0 +1,233 @@
+"""Headless checks for the Qt example's non-USD adapter boundary."""
+
+from pxr import Sdf, Usd
+
+from examples.qt_native_viewer.native_scene import NativeScene, NativeSceneAdapter
+from openusdconnect import DCCAdapter
+from openusdconnect.composed_projection import ComposedChangeProjection, ComposedProjectionState
+from openusdconnect.event_apply import apply_events
+
+
+def _apply_to_layer(stage: Usd.Stage, layer: Sdf.Layer, events: list[dict]) -> None:
+    with Usd.EditContext(stage, Usd.EditTarget(layer)):
+        apply_events(stage, events)
+
+
+def _create_xform(x: float) -> list[dict]:
+    return [
+        {"k": "ensure_prim", "prim": "/World/Cube", "typeName": "Cube"},
+        {"k": "ensure_xform_ops", "prim": "/World/Cube"},
+        {
+            "k": "set_xform_trs",
+            "prim": "/World/Cube",
+            "fields": ["t"],
+            "t": [x, 0.0, 0.0],
+        },
+    ]
+
+
+def test_native_scene_adapter_builds_application_owned_scene():
+    scene = NativeScene()
+    delivered = []
+    adapter = NativeSceneAdapter(scene, lambda events: delivered.extend(events))
+
+    events = [
+        {"k": "ensure_prim", "prim": "/World/Cube", "typeName": "Cube"},
+        {"k": "ensure_xform_ops", "prim": "/World/Cube"},
+        {
+            "k": "set_xform_trs",
+            "prim": "/World/Cube",
+            "fields": ["t", "s"],
+            "t": [2.0, 3.0, 0.0],
+            "s": [1.5, 1.0, 1.0],
+        },
+        {
+            "k": "set_gprim_attrs",
+            "prim": "/World/Cube",
+            "attrs": {"displayColor": [[0.1, 0.4, 0.9]]},
+        },
+    ]
+
+    assert adapter.targets_stage() is None
+    assert type(adapter).__mro__[1] is DCCAdapter
+    assert adapter.apply_events(events) == len(events)
+    assert delivered == events
+    assert scene.objects["/World/Cube"].type_name == "Cube"
+    assert scene.objects["/World/Cube"].translation == [2.0, 3.0, 0.0]
+    assert scene.objects["/World/Cube"].scale == [1.5, 1.0, 1.0]
+    assert scene.objects["/World/Cube"].attributes["displayColor"] == [[0.1, 0.4, 0.9]]
+
+
+def test_native_scene_adapter_reset_clears_application_state():
+    scene = NativeScene()
+    adapter = NativeSceneAdapter(scene)
+    adapter.apply_events([{"k": "ensure_prim", "prim": "/World/Cube", "typeName": "Cube"}])
+
+    adapter.reset()
+
+    assert scene.objects == {}
+
+
+def test_native_scene_adapter_dispatches_the_public_integration_contract():
+    scene = NativeScene()
+    adapter = NativeSceneAdapter(scene)
+    events = [
+        {"k": "set_stage_metadata", "upAxis": "Y", "metersPerUnit": 0.01},
+        {"k": "ensure_prim", "prim": "/World/Asset", "typeName": "Cube"},
+        {"k": "ensure_xform_ops", "prim": "/World/Asset"},
+        {
+            "k": "set_xform_trs",
+            "prim": "/World/Asset",
+            "fields": ["t"],
+            "t": [1.0, 2.0, 3.0],
+            "time": 24.0,
+        },
+        {
+            "k": "set_visibility",
+            "prim": "/World/Asset",
+            "visible": False,
+            "time": 24.0,
+        },
+        {
+            "k": "set_gprim_attrs",
+            "prim": "/World/Asset",
+            "attrs": {"size": 2.0},
+            "time": 24.0,
+        },
+        {
+            "k": "set_reference",
+            "prim": "/World/Asset",
+            "refs": [{"asset_path": "./asset.usda", "prim_path": "/Model"}],
+        },
+        {
+            "k": "set_payload",
+            "prim": "/World/Asset",
+            "payloads": [{"asset_path": "./detail.usda"}],
+        },
+        {"k": "load_payload", "prim": "/World/Asset"},
+        {"k": "unload_payload", "prim": "/World/Asset"},
+        {
+            "k": "set_variant_selections",
+            "prim": "/World/Asset",
+            "selections": {"look": "red"},
+        },
+        {"k": "set_instanceable", "prim": "/World/Asset", "instanceable": True},
+        {"k": "ensure_prim", "prim": "/World/Looks/Red", "typeName": "Material"},
+        {
+            "k": "ensure_prim",
+            "prim": "/World/Looks/Red/Surface",
+            "typeName": "Shader",
+        },
+        {
+            "k": "set_connectable_input",
+            "prim": "/World/Looks/Red/Surface",
+            "info_id": "UsdPreviewSurface",
+            "inputs": {"roughness": 0.25},
+            "input_types": {"roughness": "float"},
+        },
+        {
+            "k": "set_connectable_connection",
+            "prim": "/World/Looks/Red",
+            "connections": {
+                "outputs:surface": {
+                    "source_prim": "/World/Looks/Red/Surface",
+                    "source_attr": "outputs:surface",
+                }
+            },
+        },
+        {
+            "k": "set_material_binding",
+            "prim": "/World/Asset",
+            "material_path": "/World/Looks/Red",
+            "material_purpose": "preview",
+        },
+        {
+            "k": "ensure_prim",
+            "prim": "/World/Crowd",
+            "typeName": "PointInstancer",
+        },
+        {
+            "k": "set_point_instancer",
+            "prim": "/World/Crowd",
+            "fields": ["prototypes", "positions", "proto_indices"],
+            "prototypes": ["/World/Prototype"],
+            "positions": [[0.0, 1.0, 0.0]],
+            "proto_indices": [0],
+        },
+        {"k": "ensure_prim", "prim": "/World/Old", "typeName": "Xform"},
+        {"k": "ensure_prim", "prim": "/World/Old/Child", "typeName": "Sphere"},
+        {"k": "rename_prim", "prim": "/World/Old", "new_name": "Renamed"},
+        {"k": "deactivate_prim", "prim": "/World/Renamed", "active": False},
+        {"k": "delete_prim", "prim": "/World/Renamed"},
+    ]
+
+    assert adapter.apply_events(events) == len(events)
+
+    asset = scene.objects["/World/Asset"]
+    assert scene.stage_metadata == {"metersPerUnit": 0.01, "upAxis": "Y"}
+    assert asset.transform_samples[24.0]["t"] == [1.0, 2.0, 3.0]
+    assert asset.visibility_samples[24.0] is False
+    assert asset.attribute_samples[24.0]["size"] == 2.0
+    assert asset.references[0]["asset_path"] == "./asset.usda"
+    assert asset.payloads == [{"asset_path": "./detail.usda"}]
+    assert asset.payload_loaded is False
+    assert asset.variant_selections == {"look": "red"}
+    assert asset.instanceable is True
+    assert asset.material_bindings["preview"] == "/World/Looks/Red"
+    shader = scene.objects["/World/Looks/Red/Surface"]
+    assert shader.shader_id == "UsdPreviewSurface"
+    assert shader.connectable_inputs == {"roughness": 0.25}
+    material = scene.objects["/World/Looks/Red"]
+    assert material.type_name == "Material"
+    assert material.connectable_connections["outputs:surface"]["source_prim"] == (
+        "/World/Looks/Red/Surface"
+    )
+    assert scene.objects["/World/Crowd"].point_instancer == {
+        "prototypes": ["/World/Prototype"],
+        "proto_indices": [0],
+        "positions": [[0.0, 1.0, 0.0]],
+    }
+    assert "/World/Old" not in scene.objects
+    assert "/World/Renamed" not in scene.objects
+    assert "/World/Renamed/Child" not in scene.objects
+
+
+def test_native_scene_example_receives_composed_values_not_weaker_opinions():
+    root = Sdf.Layer.CreateAnonymous("qt-example-root.usda")
+    strong = Sdf.Layer.CreateAnonymous("animation.usda")
+    weak = Sdf.Layer.CreateAnonymous("layout.usda")
+    root.subLayerPaths = [strong.identifier, weak.identifier]
+    stage = Usd.Stage.Open(root)
+    state = ComposedProjectionState(stage)
+    scene = NativeScene()
+    adapter = NativeSceneAdapter(scene)
+
+    weak_initial = _create_xform(-4.0)
+    strong_initial = _create_xform(4.0)
+    with ComposedChangeProjection(stage, weak_initial + strong_initial, state=state) as projection:
+        _apply_to_layer(stage, weak, weak_initial)
+        _apply_to_layer(stage, strong, strong_initial)
+        adapter.apply_events(projection.build_events())
+        projection.commit()
+    assert scene.objects["/World/Cube"].translation == [4.0, 0.0, 0.0]
+
+    masked_edit = [
+        {
+            "k": "set_xform_trs",
+            "prim": "/World/Cube",
+            "fields": ["t"],
+            "t": [-1.0, 0.0, 0.0],
+        }
+    ]
+    with ComposedChangeProjection(stage, masked_edit, state=state) as projection:
+        _apply_to_layer(stage, weak, masked_edit)
+        assert projection.build_events() == []
+        projection.commit()
+    assert scene.objects["/World/Cube"].translation == [4.0, 0.0, 0.0]
+
+    reveal_weaker = [{"k": "delete_prim", "prim": "/World/Cube"}]
+    with ComposedChangeProjection(stage, reveal_weaker, state=state) as projection:
+        _apply_to_layer(stage, strong, reveal_weaker)
+        adapter.apply_events(projection.build_events())
+        projection.commit()
+    assert scene.objects["/World/Cube"].translation == [-1.0, 0.0, 0.0]

--- a/uv.lock
+++ b/uv.lock
@@ -1024,6 +1024,9 @@ mcp = [
 profile = [
     { name = "py-spy" },
 ]
+qt-example = [
+    { name = "pyside6-essentials" },
+]
 vfs = [
     { name = "cheroot" },
     { name = "wsgidav" },
@@ -1049,6 +1052,7 @@ dev = [
 ]
 mcp = [{ name = "mcp", specifier = ">=1.2,<2" }]
 profile = [{ name = "py-spy", specifier = "==0.4.2" }]
+qt-example = [{ name = "pyside6-essentials", specifier = "==6.11.1" }]
 vfs = [
     { name = "cheroot", specifier = "==10.0.1" },
     { name = "wsgidav", specifier = "==4.3.3" },
@@ -1307,6 +1311,21 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/da/10d9197e7370eb4fed8df5fc547b7548dec88e5c5949e2d450db4ae96feb/pyside6_essentials-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:228de53c2bc26b07e5021fbe3614fc44ca08e4dab9999af08c2b389d2c239957", size = 110352945, upload-time = "2026-05-13T09:43:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/0e1237c4400bec7e335d2c4eeb49bc40d9fd88a9ac44ca9083ce1abdc308/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e3ef7027b41e4e55fadb56e3b3257dc8ee92154b639fe67fc4c8e05e9d976c60", size = 79908535, upload-time = "2026-05-13T09:43:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c5/da4c5f23c6540ac5211a1f60177c8dee84b1bf40f2719479587ab8c60731/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a039b6da68a3a4b9d243217b2b98d475eed3f617159ef6be925badab53c11b0d", size = 78960051, upload-time = "2026-05-13T09:43:35.423Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/b663ecc96ca57b5c91b83b6615d6b174380b0faf30338125c26e053d6aa7/pyside6_essentials-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:63311bd48e32c584599ab04b9ef7c324082374cd2c9fa533f978fb893bb47e40", size = 77549267, upload-time = "2026-05-13T09:43:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/eb6723faf5cb7fa581145da1c15f40d641b96e080f0491af2f1859fdeedb/pyside6_essentials-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:11253ea52aabecefe9febddbbe78b43a824129e3af1cec98431028fba7fa954f", size = 57964512, upload-time = "2026-05-13T09:43:52.968Z" },
 ]
 
 [[package]]
@@ -1570,6 +1589,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f3/f2b63df0251e7cd3172ea28e32ede52739de9566bcefcd0178681538ac81/shiboken6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1a16867f103ef1c662a5f09dfed03273a9f81688b174555162c58e83650a3f02", size = 476874, upload-time = "2026-05-13T09:47:01.091Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9b/e0355d8897b5c150770f1d95718aad17d432fcc9c035c04f3f58427d4693/shiboken6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9a8bccfafc8805254cabcfa1edfaf55cd52889f4998c91ad0d9a4433fb1bcdbe", size = 272222, upload-time = "2026-05-13T09:47:02.653Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/dd4f1defed400be03340f2ede34b61f846776650b4e7ed9ebaf4c71979a2/shiboken6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:1bd2f4314414df2d122d9f646e03b731bc6d6b5f77a5f53f99a4fe4e97d84e6f", size = 270350, upload-time = "2026-05-13T09:47:04.02Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/3f6fb2ee65b534193fb4ef713dd619dc31dadff5d12c16979a7699ad58be/shiboken6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:c2c6863aa80ec18c0f82cea3417837b279cdc60024ac17123461dc9042577df7", size = 1223647, upload-time = "2026-05-13T09:47:05.924Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d1/f15ca0e1666faae02c945f48e745ea35f8fcd8243b176109b4e2c4251f47/shiboken6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:7c8d9af17db4495d4fa5b1c393f218311c4855546b9dfa6a0bd21bcd66b55e9d", size = 1784170, upload-time = "2026-05-13T09:47:07.617Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- receive composed layered changes through UsdReceiver and DCCAdapter
- render the adapter-owned scene with an interactive OpenGL viewport
- demonstrate masked and revealed opinions over the networked server flow
- add focused tests, documentation, and an opt-in PySide dependency group